### PR TITLE
[#1] Feat: API 응답 형식 통일

### DIFF
--- a/src/main/java/hansung/hansung_connect/common/exception/code/BaseCode.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/BaseCode.java
@@ -1,0 +1,8 @@
+package hansung.hansung_connect.common.exception.code;
+
+public interface BaseCode {
+
+    ReasonDTO getReason();
+
+    ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/hansung/hansung_connect/common/exception/code/BaseErrorCode.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package hansung.hansung_connect.common.exception.code;
+
+public interface BaseErrorCode {
+
+    ErrorReasonDTO getReason();
+
+    ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/hansung/hansung_connect/common/exception/code/ErrorReasonDTO.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/ErrorReasonDTO.java
@@ -1,0 +1,18 @@
+package hansung.hansung_connect.common.exception.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/hansung/hansung_connect/common/exception/code/ReasonDTO.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/ReasonDTO.java
@@ -1,0 +1,18 @@
+package hansung.hansung_connect.common.exception.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+
+    private HttpStatus httpStatus;
+
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;}
+}

--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
@@ -1,0 +1,42 @@
+package hansung.hansung_connect.common.exception.code.status;
+
+import hansung.hansung_connect.common.exception.code.BaseErrorCode;
+import hansung.hansung_connect.common.exception.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+
+    // 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "해당 리소스를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/SuccessStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/SuccessStatus.java
@@ -1,0 +1,41 @@
+package hansung.hansung_connect.common.exception.code.status;
+
+import hansung.hansung_connect.common.exception.code.BaseCode;
+import hansung.hansung_connect.common.exception.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+
+    // 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
+    _CREATED(HttpStatus.CREATED, "COMMON201", "생성되었습니다."),
+    _NO_CONTENT(HttpStatus.NO_CONTENT, "COMMON204", "No content입니다.");
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/hansung/hansung_connect/common/response/ApiResponse.java
+++ b/src/main/java/hansung/hansung_connect/common/response/ApiResponse.java
@@ -1,0 +1,37 @@
+package hansung.hansung_connect.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import hansung.hansung_connect.common.exception.code.BaseCode;
+import hansung.hansung_connect.common.exception.code.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/hansung/hansung_connect/test/TestController.java
+++ b/src/main/java/hansung/hansung_connect/test/TestController.java
@@ -1,0 +1,18 @@
+package hansung.hansung_connect.test;
+
+import hansung.hansung_connect.common.response.ApiResponse;
+import hansung.hansung_connect.test.dto.TestResponse;
+import hansung.hansung_connect.test.dto.TestResponse.TestDTO;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+public class TestController {
+
+    @GetMapping("")
+    public ApiResponse<TestDTO> test() {
+        return ApiResponse.onSuccess(TestConverter.toTempTestDTO());
+    }
+}

--- a/src/main/java/hansung/hansung_connect/test/TestConverter.java
+++ b/src/main/java/hansung/hansung_connect/test/TestConverter.java
@@ -1,0 +1,11 @@
+package hansung.hansung_connect.test;
+
+import hansung.hansung_connect.test.dto.TestResponse;
+
+public class TestConverter {
+    public static TestResponse.TestDTO toTempTestDTO(){
+        return TestResponse.TestDTO.builder()
+                .testString("테스트 성공")
+                .build();
+    }
+}

--- a/src/main/java/hansung/hansung_connect/test/dto/TestResponse.java
+++ b/src/main/java/hansung/hansung_connect/test/dto/TestResponse.java
@@ -1,0 +1,16 @@
+package hansung.hansung_connect.test.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TestResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TestDTO{
+        String testString;
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
#1 

## 💡 주요 변경사항
API 응답 형식 통일과 관련된 코드를 작성했습니다. 
이후 API 개발 과정에서 Response의 형식을 통일할 수 있도록 하였습니다. 

## 🎯 테스트 방법
1. 프로젝트 실행
2. localhost:8080/test 접속 (아직 스웨거 연동이 안된 상태라 직접 url을 날려봅니다.)
3. 아래와 같이 응답형식 통일에 대한 테스트 성공 메시지를 확인합니다.
<img width="886" height="653" alt="image" src="https://github.com/user-attachments/assets/1f550d35-abc7-4c5e-9b1b-59763948a9a2" />

## 🚨 논의하고 싶은 점
X