### PR TITLE
[#2] Feat: 전역 예외처리 핸들러 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/hansung/hansung_connect/common/exception/GeneralException.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/GeneralException.java
@@ -1,0 +1,23 @@
+package hansung.hansung_connect.common.exception;
+
+import hansung.hansung_connect.common.exception.code.BaseErrorCode;
+import hansung.hansung_connect.common.exception.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+
+    private BaseErrorCode code;
+
+    // 에러 상태 및 메시지만 담은 DTO 반환
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    // HTTP 상태 코드까지 포함한 DTO 반환
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
@@ -15,7 +15,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
-    _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "해당 리소스를 찾을 수 없습니다.");
+    _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "해당 리소스를 찾을 수 없습니다."),
+
+    // For test
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트용 에러메세지입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/hansung/hansung_connect/common/exception/handler/ExceptionAdvice.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/handler/ExceptionAdvice.java
@@ -1,0 +1,217 @@
+package hansung.hansung_connect.common.exception.handler;
+
+import hansung.hansung_connect.common.exception.GeneralException;
+import hansung.hansung_connect.common.exception.code.ErrorReasonDTO;
+import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
+import hansung.hansung_connect.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 전역 예외 처리를 담당하는 클래스.
+ * 모든 컨트롤러에서 발생하는 예외를 가로채어 공통된 방식으로 응답을 반환한다.
+ */
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})  // @RestController가 붙은 컨트롤러에서 발생하는 예외 처리
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    /**
+     * ConstraintViolationException 예외 처리 (DTO 유효성 검사 실패 시 발생).
+     *
+     * @param e       발생한 예외
+     * @param request 웹 요청 정보
+     * @return 에러 응답
+     */
+    @ExceptionHandler
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        // 예외에서 첫 번째 에러 메시지를 추출
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("ConstraintViolationException 추출 도중 에러 발생"));
+
+        // ErrorStatus에서 에러 메시지에 해당하는 상태를 찾아 응답 반환
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+    }
+
+    /**
+     * MethodArgumentNotValidException 예외 처리 (@Valid 실패 시 발생).
+     *
+     * @param e       발생한 예외
+     * @param headers HTTP 헤더
+     * @param status  HTTP 상태 코드
+     * @param request 웹 요청 정보
+     * @return 에러 응답
+     */
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException e,
+                                                               HttpHeaders headers,
+                                                               HttpStatusCode status,
+                                                               WebRequest request) {
+        // 모든 필드 에러를 저장할 Map 초기화
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        // 각 필드 에러 메시지를 Map에 추가 (중복 에러는 ','로 병합)
+        e.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            String fieldName = fieldError.getField();
+            String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+            errors.merge(fieldName, errorMessage, (existingErrorMessage, newErrorMessage) ->
+                    existingErrorMessage + ", " + newErrorMessage);
+        });
+
+        // BAD_REQUEST 상태로 응답 반환
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+    }
+
+    /**
+     * Exception (기본 예외) 처리.
+     * 예상하지 못한 예외가 발생했을 때 호출된다.
+     *
+     * @param e       발생한 예외
+     * @param request 웹 요청 정보
+     * @return 에러 응답
+     */
+    @ExceptionHandler
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        // 예외 스택 트레이스 출력 (디버깅 목적)
+        e.printStackTrace();
+
+        // INTERNAL_SERVER_ERROR 상태로 응답 반환
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR,
+                HttpHeaders.EMPTY,
+                ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(),
+                request, e.getMessage());
+    }
+
+    /**
+     * GeneralException 커스텀 예외 처리.
+     *
+     * @param generalException 커스텀 예외
+     * @param request          웹 요청 정보
+     * @return 에러 응답
+     */
+    @ExceptionHandler(value = GeneralException.class)
+    public ResponseEntity onThrowException(GeneralException generalException, HttpServletRequest request) {
+        // GeneralException에서 에러 상태 정보 추출
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+
+        // 에러 상태로 응답 반환
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
+    }
+
+    /**
+     * 공통 예외 처리 메서드 - HttpServletRequest를 기반으로 응답 반환.
+     *
+     * @param e       발생한 예외
+     * @param reason  에러 상태 정보 (ErrorReasonDTO)
+     * @param headers HTTP 헤더
+     * @param request HTTP 서블릿 요청 객체
+     * @return 에러 응답
+     */
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+        // ApiResponse 객체를 생성하여 실패 응답 생성
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
+
+        WebRequest webRequest = new ServletWebRequest(request);
+
+        // ResponseEntityExceptionHandler의 기본 예외 처리 메서드 호출
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                reason.getHttpStatus(),
+                webRequest
+        );
+    }
+
+    /**
+     * 공통 예외 처리 메서드 - 특정 에러 메시지를 포함하여 응답 반환.
+     *
+     * @param e                발생한 예외
+     * @param errorCommonStatus 에러 상태 (ErrorStatus)
+     * @param headers          HTTP 헤더
+     * @param status           HTTP 상태 코드
+     * @param request          웹 요청 정보
+     * @param errorPoint       에러 발생 지점 메시지
+     * @return 에러 응답
+     */
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorCommonStatus,
+                                                                HttpHeaders headers, HttpStatus status,
+                                                                WebRequest request, String errorPoint) {
+        // 실패 응답에 에러 발생 지점 메시지 포함
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), errorPoint);
+
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                status,
+                request
+        );
+    }
+
+    /**
+     * 공통 예외 처리 메서드 - 유효성 검사 실패 필드 정보 포함.
+     *
+     * @param e                발생한 예외
+     * @param headers          HTTP 헤더
+     * @param errorCommonStatus 에러 상태 (ErrorStatus)
+     * @param request          웹 요청 정보
+     * @param errorArgs        필드별 에러 정보 (Map)
+     * @return 에러 응답
+     */
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers,
+                                                               ErrorStatus errorCommonStatus,
+                                                               WebRequest request,
+                                                               Map<String, String> errorArgs) {
+        // 실패 응답에 필드별 에러 메시지 포함
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), errorArgs);
+
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+
+    /**
+     * 공통 예외 처리 메서드 - 제약 조건 위반 예외 처리.
+     *
+     * @param e                발생한 예외
+     * @param errorCommonStatus 에러 상태 (ErrorStatus)
+     * @param headers          HTTP 헤더
+     * @param request          웹 요청 정보
+     * @return 에러 응답
+     */
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorCommonStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorCommonStatus.getCode(), errorCommonStatus.getMessage(), null);
+
+        return super.handleExceptionInternal(
+                e,
+                body,
+                headers,
+                errorCommonStatus.getHttpStatus(),
+                request
+        );
+    }
+}

--- a/src/main/java/hansung/hansung_connect/common/exception/handler/TempHandler.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/handler/TempHandler.java
@@ -1,0 +1,11 @@
+package hansung.hansung_connect.common.exception.handler;
+
+import hansung.hansung_connect.common.exception.GeneralException;
+import hansung.hansung_connect.common.exception.code.BaseErrorCode;
+
+public class TempHandler extends GeneralException {
+
+    public TempHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/hansung/hansung_connect/config/SwaggerConfig.java
+++ b/src/main/java/hansung/hansung_connect/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package hansung.hansung_connect.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI HSConnectAPI() {
+
+        Info info = new Info()
+                .title("Hansung Connect API")
+                .description("Hansung Connect API 명세서")
+                .version("1.0.0");
+
+        String jwtSchemeName = "JWT TOKEN";
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/hansung/hansung_connect/test/TestController.java
+++ b/src/main/java/hansung/hansung_connect/test/TestController.java
@@ -3,16 +3,35 @@ package hansung.hansung_connect.test;
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.test.dto.TestResponse;
 import hansung.hansung_connect.test.dto.TestResponse.TestDTO;
+import hansung.hansung_connect.test.service.TestQueryService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "Test", description = "테스트용 API")
 @RestController
 @RequestMapping("/test")
+@RequiredArgsConstructor
 public class TestController {
+
+    private final TestQueryService testQueryService;
 
     @GetMapping("")
     public ApiResponse<TestDTO> test() {
         return ApiResponse.onSuccess(TestConverter.toTempTestDTO());
+    }
+
+    @Operation(
+            summary = "에러 핸들링 테스트",
+            description = "Query String으로 전달된 flag 값이 1일 경우 예외를 발생시키는 테스트용 API입니다."
+    )
+    @GetMapping("/exception")
+    public ApiResponse<TestResponse.ExceptionDTO> exceptionAPI(@RequestParam Integer flag){
+        testQueryService.CheckFlag(flag);
+        return ApiResponse.onSuccess(TestConverter.toExceptionDTO(flag));
     }
 }

--- a/src/main/java/hansung/hansung_connect/test/TestConverter.java
+++ b/src/main/java/hansung/hansung_connect/test/TestConverter.java
@@ -8,4 +8,9 @@ public class TestConverter {
                 .testString("테스트 성공")
                 .build();
     }
+    public static TestResponse.ExceptionDTO toExceptionDTO(Integer flag){
+        return TestResponse.ExceptionDTO.builder()
+                .flag(flag)
+                .build();
+    }
 }

--- a/src/main/java/hansung/hansung_connect/test/dto/TestResponse.java
+++ b/src/main/java/hansung/hansung_connect/test/dto/TestResponse.java
@@ -13,4 +13,11 @@ public class TestResponse {
     public static class TestDTO{
         String testString;
     }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExceptionDTO{
+        Integer flag;
+    }
 }

--- a/src/main/java/hansung/hansung_connect/test/service/TestQueryService.java
+++ b/src/main/java/hansung/hansung_connect/test/service/TestQueryService.java
@@ -1,0 +1,5 @@
+package hansung.hansung_connect.test.service;
+
+public interface TestQueryService {
+    void CheckFlag(Integer flag);
+}

--- a/src/main/java/hansung/hansung_connect/test/service/TestQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/test/service/TestQueryServiceImpl.java
@@ -1,0 +1,17 @@
+package hansung.hansung_connect.test.service;
+
+import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
+import hansung.hansung_connect.common.exception.handler.TempHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TestQueryServiceImpl implements TestQueryService {
+
+    @Override
+    public void CheckFlag(Integer flag) {
+        if (flag == 1)
+            throw new TempHandler(ErrorStatus.TEMP_EXCEPTION);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
#2


## 💡 주요 변경사항
GeneralException과 ExceptionAdvice를 추가하여 전역 예외 처리 구조를 설정하였고,
에러 핸들링 테스트를 위한 테스트 코드를 작성하고, 예외처리가 일관된 형식으로 잘 이루어지는지 확인하였습니다. 
추가로, springdoc-openapi 버전을 2.8.5로 업그레이드하였습니다.


## 🎯 테스트 방법
1. 웹 브라우저에서 Swagger UI에 접속.
2. /test/exception 엔드포인트를 선택한 뒤, flag 값을 1로 입력하고 요청을 보내기.
3. 에러 메시지가 정상적으로 반환되는지 확인.
> <img width="400" alt="image" src="https://github.com/user-attachments/assets/017a5ce9-d108-4537-99d6-1b086cb53c2f" />
4. 또는, Swagger를 사용하지 않고 웹 브라우저 주소창에 http://localhost:8080/test/exception?flag=1 을 직접 입력해 테스트.
> <img width="400" height="417" alt="image" src="https://github.com/user-attachments/assets/4bf0f525-fc64-4781-988b-fbc9c15d2e16" />


## 🚨 논의하고 싶은 점
없습니다!

