### PR TITLE
[#17] 게시글 작성 기능 구현

### DIFF
--- a/src/main/java/hansung/hansung_connect/HansungConnectApplication.java
+++ b/src/main/java/hansung/hansung_connect/HansungConnectApplication.java
@@ -2,7 +2,9 @@ package hansung.hansung_connect;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class HansungConnectApplication {
 

--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
@@ -18,7 +18,10 @@ public enum ErrorStatus implements BaseErrorCode {
     _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "해당 리소스를 찾을 수 없습니다."),
 
     // For test
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트용 에러메세지입니다.");
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트용 에러메세지입니다."),
+
+    // 유저 관련 응답
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -3,6 +3,7 @@ package hansung.hansung_connect.domain.post.controller;
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.post.dto.PostRequestDto;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto;
+import hansung.hansung_connect.domain.post.service.PostCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PostController {
 
+    private final PostCommandService postCommandService;
+
     @Operation(
             summary = "게시글 작성",
             description = "게시글을 작성하는 API입니다. postType으로 게시글 유형을 입력해주세요."
@@ -28,7 +31,8 @@ public class PostController {
     public ApiResponse<PostResponseDto.PostCreateResponse> createPost(
             @RequestBody PostRequestDto.PostCreateRequest request
     ) {
-        return ApiResponse.onSuccess(null);
+        Long userId = 1L;
+        return ApiResponse.onSuccess(postCommandService.createPost(userId, request));
     }
 
     @Operation(

--- a/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
@@ -1,0 +1,27 @@
+package hansung.hansung_connect.domain.post.converter;
+
+import hansung.hansung_connect.domain.post.dto.PostRequestDto;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto;
+import hansung.hansung_connect.domain.post.entity.Post;
+import hansung.hansung_connect.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostConverter {
+
+    public Post toPost(User user, PostRequestDto.PostCreateRequest request) {
+        return Post.builder()
+                .type(request.getPostType())
+                .title(request.getTitle())
+                .body(request.getBody())
+                .views(0L)
+                .user(user)
+                .build();
+    }
+
+    public PostResponseDto.PostCreateResponse toPostCreateResponse(Post post) {
+        return PostResponseDto.PostCreateResponse.builder()
+                .postId(post.getId())
+                .build();
+    }
+}

--- a/src/main/java/hansung/hansung_connect/domain/post/repository/PostRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package hansung.hansung_connect.domain.post.repository;
+
+import hansung.hansung_connect.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostCommandService.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostCommandService.java
@@ -1,0 +1,8 @@
+package hansung.hansung_connect.domain.post.service;
+
+import hansung.hansung_connect.domain.post.dto.PostRequestDto;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto;
+
+public interface PostCommandService {
+    PostResponseDto.PostCreateResponse createPost(Long userId, PostRequestDto.PostCreateRequest request);
+}

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostCommandServiceImpl.java
@@ -1,0 +1,36 @@
+package hansung.hansung_connect.domain.post.service;
+
+import hansung.hansung_connect.common.exception.GeneralException;
+import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
+import hansung.hansung_connect.domain.post.converter.PostConverter;
+import hansung.hansung_connect.domain.post.dto.PostRequestDto.PostCreateRequest;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostCreateResponse;
+import hansung.hansung_connect.domain.post.entity.Post;
+import hansung.hansung_connect.domain.post.repository.PostRepository;
+import hansung.hansung_connect.domain.user.entity.User;
+import hansung.hansung_connect.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostCommandServiceImpl implements PostCommandService {
+
+    private final PostConverter postConverter;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public PostCreateResponse createPost(Long userId, PostCreateRequest request) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Post post = postRepository.save(postConverter.toPost(user, request));
+
+        return postConverter.toPostCreateResponse(post);
+    }
+
+}

--- a/src/main/java/hansung/hansung_connect/domain/user/repository/UserRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package hansung.hansung_connect.domain.user.repository;
+
+import hansung.hansung_connect.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 🔍 관련 이슈
#17

## 💡 주요 변경사항
게시글 작성 기능을 추가했습니다.

## 🎯 테스트 방법
1. user 생성 - db에서 아이디가 1인 유저를 생성
2. 스웨거에서 게시글 작성 api 테스트
3. db에서 post생성 확인

## 🚨 논의하고 싶은 점
현재 회원가입, 로그인이 구현되지 않아서 게시글을 작성하면 id가 1인 유저의 게시글로 생성하도록 되어있습니다.