### PR TITLE
[#19] 게시글 단건 조회 기능

### DIFF
--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
@@ -21,7 +21,10 @@ public enum ErrorStatus implements BaseErrorCode {
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트용 에러메세지입니다."),
 
     // 유저 관련 응답
-    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자를 찾을 수 없습니다."),
+
+    // 게시글 관련 응답
+    POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST4001", "게시글을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/hansung/hansung_connect/domain/commnet/repository/CommentRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package hansung.hansung_connect.domain.commnet.repository;
+
+import hansung.hansung_connect.domain.commnet.entity.Comment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByPostIdOrderByCreatedAtAsc(Long postId);
+}

--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.post.dto.PostRequestDto;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto;
 import hansung.hansung_connect.domain.post.service.PostCommandService;
+import hansung.hansung_connect.domain.post.service.PostQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PostController {
 
     private final PostCommandService postCommandService;
+    private final PostQueryService postQueryService;
 
     @Operation(
             summary = "게시글 작성",
@@ -55,7 +57,8 @@ public class PostController {
     public ApiResponse<PostResponseDto.PostResponse> getPost(
             @PathVariable("postId") Long postId
     ) {
-        return ApiResponse.onSuccess(null);
+        Long userId = 1L;
+        return ApiResponse.onSuccess(postQueryService.getPost(userId, postId));
     }
 
     @Operation(

--- a/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
@@ -1,9 +1,12 @@
 package hansung.hansung_connect.domain.post.converter;
 
+import hansung.hansung_connect.domain.commnet.entity.Comment;
 import hansung.hansung_connect.domain.post.dto.PostRequestDto;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostCommentResponse;
 import hansung.hansung_connect.domain.post.entity.Post;
 import hansung.hansung_connect.domain.user.entity.User;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,6 +25,38 @@ public class PostConverter {
     public PostResponseDto.PostCreateResponse toPostCreateResponse(Post post) {
         return PostResponseDto.PostCreateResponse.builder()
                 .postId(post.getId())
+                .build();
+    }
+
+    public PostResponseDto.PostResponse toPostResponse(Post post, List<Comment> comments) {
+        return PostResponseDto.PostResponse.builder()
+                .id(post.getId())
+                .author(post.getUser().getName())
+
+                .build();
+
+    }
+
+    public PostResponseDto.PostResponse toPostResponse(Post post, Long currentUserId, List<PostCommentResponse> commentResponses) {
+        return PostResponseDto.PostResponse.builder()
+                .id(post.getId())
+                .author(post.getUser().getName())
+                .studentId(post.getUser().getStudentNumber())
+                .authorStatus(post.getUser().getAcademicStatus().toString())
+                .title(post.getTitle())
+                .body(post.getBody())
+                .mine(post.getUser().getId().equals(currentUserId))
+                .comments(commentResponses)
+                .build();
+    }
+
+    public PostResponseDto.PostCommentResponse toPostCommentResponse(Comment comment, Long currentUserId) {
+        return PostResponseDto.PostCommentResponse.builder()
+                .id(comment.getId())
+                .commenter(comment.getUser().getName())
+                .commenterStatus(comment.getUser().getAcademicStatus().toString())
+                .content(comment.getBody())
+                .mine(comment.getUser().getId().equals(currentUserId))
                 .build();
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
@@ -22,6 +22,7 @@ public class PostResponseDto {
     }
 
     @Getter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(name = "PostSummaryResponse", title = "게시글 요약 정보")
@@ -46,6 +47,7 @@ public class PostResponseDto {
     }
 
     @Getter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(name = "PostListResponse", title = "게시글 목록 조회 응답")
@@ -55,6 +57,7 @@ public class PostResponseDto {
     }
 
     @Getter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(name = "PostResponse", title = "게시글 상세 조회 응답")
@@ -78,7 +81,7 @@ public class PostResponseDto {
         private String body;
 
         @Schema(description = "자신의 게시글인지 여부", example = "false")
-        private boolean isMine;
+        private boolean mine;
 
         @Schema(description = "게시글의 댓글 리스트")
         private List<PostCommentResponse> comments;
@@ -86,6 +89,7 @@ public class PostResponseDto {
     }
 
     @Getter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(name = "PostCommentResponse", title = "게시글의 댓글 리스트 응답")
@@ -103,7 +107,7 @@ public class PostResponseDto {
         private String content;
 
         @Schema(description = "자신의 댓글인지 여부", example = "false")
-        private boolean isMine;
+        private boolean mine;
 
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
@@ -1,0 +1,8 @@
+package hansung.hansung_connect.domain.post.service;
+
+import hansung.hansung_connect.domain.post.dto.PostResponseDto;
+
+public interface PostQueryService {
+
+    PostResponseDto.PostResponse getPost(Long userId, Long postId);
+}

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
@@ -1,0 +1,40 @@
+package hansung.hansung_connect.domain.post.service;
+
+import hansung.hansung_connect.common.exception.GeneralException;
+import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
+import hansung.hansung_connect.domain.commnet.entity.Comment;
+import hansung.hansung_connect.domain.commnet.repository.CommentRepository;
+import hansung.hansung_connect.domain.post.converter.PostConverter;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostResponse;
+import hansung.hansung_connect.domain.post.entity.Post;
+import hansung.hansung_connect.domain.post.repository.PostRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PostQueryServiceImpl implements PostQueryService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final PostConverter postConverter;
+
+    @Override
+    public PostResponse getPost(Long userId, Long postId) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        List<Comment> comments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId);
+
+        List<PostResponseDto.PostCommentResponse> commentResponses = comments.stream()
+                .map(comment -> postConverter.toPostCommentResponse(comment, userId))
+                .toList();
+
+        return postConverter.toPostResponse(post, userId, commentResponses);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
#19

## 💡 주요 변경사항
게시글 단건 조회 기능을 구현하였습니다.

## 🎯 테스트 방법
1. user 생성 - db에서 아이디가 1인 유저를 생성
2. 게시글 생성 - db생성 or 게시글 작성 api 활용
3. (선택) 댓글 생성 - db에서 생성
4. 스웨거에서 api 테스트

## 🚨 논의하고 싶은 점
