### PR TITLE
[#22] 게시글 리스트 조회 API

### DIFF
--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
@@ -24,7 +24,9 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자를 찾을 수 없습니다."),
 
     // 게시글 관련 응답
-    POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST4001", "게시글을 찾을 수 없습니다.");
+    POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST4001", "게시글을 찾을 수 없습니다."),
+    POST_QUERY_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "POST4002", "게시글 조회 타입이 잘못되었습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
@@ -25,7 +25,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 게시글 관련 응답
     POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST4001", "게시글을 찾을 수 없습니다."),
-    POST_QUERY_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "POST4002", "게시글 조회 타입이 잘못되었습니다.");
+    POST_QUERY_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "POST4002", "게시글 조회 타입이 잘못되었습니다."),
+    POST_LIST_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "POST5001", "게시글 리스트가 비어있습니다."),
+    INVALID_PAGE_FOR_POPULAR(HttpStatus.BAD_REQUEST,"POST4003", "인기 게시글은 0번 페이지만 조회 가능합니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -3,6 +3,7 @@ package hansung.hansung_connect.domain.post.controller;
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.post.dto.PostRequestDto;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto;
+import hansung.hansung_connect.domain.post.dto.enums.PostQueryType;
 import hansung.hansung_connect.domain.post.service.PostCommandService;
 import hansung.hansung_connect.domain.post.service.PostQueryService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -44,7 +45,7 @@ public class PostController {
     )
     @GetMapping("")
     public ApiResponse<PostResponseDto.PostListResponse> getPosts(
-            @RequestParam(required = false, defaultValue = "popular") String type
+            @RequestParam(required = false, defaultValue = "popular") PostQueryType type
     ) {
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -7,6 +7,7 @@ import hansung.hansung_connect.domain.post.dto.enums.PostQueryType;
 import hansung.hansung_connect.domain.post.service.PostCommandService;
 import hansung.hansung_connect.domain.post.service.PostQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,12 +41,21 @@ public class PostController {
 
     @Operation(
             summary = "게시글 리스트 조회",
-            description = "게시글 리스트를 조회하는 API입니다. Query Parameter로 게시글 유형을 입력해주세요."
-                    + " [popular, free, promotion, notice]"
+            description = """
+            게시글 유형별 리스트를 조회합니다.
+            - popular: 인기글
+            - free: 자유 게시판
+            - promotion: 홍보 게시판
+            - notice: 공지 게시글
+            한 페이지에 게시글의 수는 20입니다.
+            """
     )
     @GetMapping("")
     public ApiResponse<PostResponseDto.PostListResponse> getPosts(
-            @RequestParam(required = false, defaultValue = "popular") PostQueryType type
+            @Parameter(description = "게시글 조회 유형", example = "popular")
+            @RequestParam(defaultValue = "popular") PostQueryType type,
+            @Parameter(description = "페이지 번호")
+            @RequestParam(defaultValue = "0") int page
     ) {
         return ApiResponse.onSuccess(null);
     }

--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -47,17 +47,19 @@ public class PostController {
             - free: 자유 게시판
             - promotion: 홍보 게시판
             - notice: 공지 게시글
+            
             한 페이지에 게시글의 수는 20입니다.
             """
     )
     @GetMapping("")
     public ApiResponse<PostResponseDto.PostListResponse> getPosts(
             @Parameter(description = "게시글 조회 유형", example = "popular")
-            @RequestParam(defaultValue = "popular") PostQueryType type,
+            @RequestParam(defaultValue = "popular") String type,
             @Parameter(description = "페이지 번호")
             @RequestParam(defaultValue = "0") int page
     ) {
-        return ApiResponse.onSuccess(null);
+        PostQueryType postType = PostQueryType.from(type);
+        return ApiResponse.onSuccess(postQueryService.getPostsByType(postType, page));
     }
 
     @Operation(

--- a/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
@@ -7,10 +7,13 @@ import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostCommentRespon
 import hansung.hansung_connect.domain.post.entity.Post;
 import hansung.hansung_connect.domain.user.entity.User;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PostConverter {
+
+    private static final int SUMMARY_LENGTH = 30;
 
     public Post toPost(User user, PostRequestDto.PostCreateRequest request) {
         return Post.builder()
@@ -28,21 +31,12 @@ public class PostConverter {
                 .build();
     }
 
-    public PostResponseDto.PostResponse toPostResponse(Post post, List<Comment> comments) {
-        return PostResponseDto.PostResponse.builder()
-                .id(post.getId())
-                .author(post.getUser().getName())
-
-                .build();
-
-    }
-
     public PostResponseDto.PostResponse toPostResponse(Post post, Long currentUserId, List<PostCommentResponse> commentResponses) {
         return PostResponseDto.PostResponse.builder()
                 .id(post.getId())
                 .author(post.getUser().getName())
                 .studentId(post.getUser().getStudentNumber())
-                .authorStatus(post.getUser().getAcademicStatus().toString())
+                .authorStatus(post.getUser().getAcademicStatus().getStatus())
                 .title(post.getTitle())
                 .body(post.getBody())
                 .mine(post.getUser().getId().equals(currentUserId))
@@ -57,6 +51,35 @@ public class PostConverter {
                 .commenterStatus(comment.getUser().getAcademicStatus().toString())
                 .content(comment.getBody())
                 .mine(comment.getUser().getId().equals(currentUserId))
+                .build();
+    }
+
+    public PostResponseDto.PostSummaryResponse toPostSummaryResponse(Post post) {
+        String body = post.getBody();
+        String summary = body.length() <= SUMMARY_LENGTH
+                ? body
+                : body.substring(0, SUMMARY_LENGTH) + "...";
+
+        return PostResponseDto.PostSummaryResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .summary(summary)
+                .author(post.getUser().getName())
+                .studentId(post.getUser().getStudentNumber())
+                .authorStatus(post.getUser().getAcademicStatus().getStatus())
+                .build();
+    }
+
+    public PostResponseDto.PostListResponse toPostListResponse(Page<Post> postPage) {
+        List<PostResponseDto.PostSummaryResponse> posts = postPage.getContent().stream()
+                .map(this::toPostSummaryResponse)
+                .toList();
+
+        return PostResponseDto.PostListResponse.builder()
+                .posts(posts)
+                .currentPage(postPage.getNumber())
+                .hasNext(postPage.hasNext())
+                .totalElements(postPage.getTotalElements())
                 .build();
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
@@ -54,6 +54,15 @@ public class PostResponseDto {
     public static class PostListResponse {
         @Schema(description = "게시글 요약 정보")
         private List<PostSummaryResponse> posts;
+
+        @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+        private int currentPage;
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        private boolean hasNext;
+
+        @Schema(description = "총 게시글 수", example = "132")
+        private long totalElements;
     }
 
     @Getter

--- a/src/main/java/hansung/hansung_connect/domain/post/dto/enums/PostQueryType.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/dto/enums/PostQueryType.java
@@ -1,0 +1,32 @@
+package hansung.hansung_connect.domain.post.dto.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import hansung.hansung_connect.common.exception.GeneralException;
+import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시글 조회 유형 [POPULAR, FREE, PROMOTION, NOTICE]")
+public enum PostQueryType {
+    POPULAR,
+    FREE,
+    PROMOTION,
+    NOTICE;
+
+    @JsonCreator
+    public static PostQueryType from(String value) {
+        if(value == null) {
+            return null;
+        }
+        try {
+            return PostQueryType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new GeneralException(ErrorStatus.POST_QUERY_TYPE_EXCEPTION);
+        }
+    }
+
+    @JsonValue
+    public String toValue() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src/main/java/hansung/hansung_connect/domain/post/entity/enums/PostType.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/entity/enums/PostType.java
@@ -2,5 +2,6 @@ package hansung.hansung_connect.domain.post.entity.enums;
 
 public enum PostType {
     FREE,   // 자유게시판
-    PROMOTION // 홍보게시판
+    PROMOTION, // 홍보게시판
+    NOTICE //운영진 공지글
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/repository/PostRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/repository/PostRepository.java
@@ -1,7 +1,24 @@
 package hansung.hansung_connect.domain.post.repository;
 
 import hansung.hansung_connect.domain.post.entity.Post;
+import hansung.hansung_connect.domain.post.entity.enums.PostType;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findByType(PostType postType, Pageable pageable);
+
+    @Query("SELECT p FROM Post p " +
+            "WHERE p.type IN :types AND p.updatedAt >= :threshold " +
+            "ORDER BY p.views DESC")
+    Page<Post> findPopularPostsInLast24Hours(
+            @Param("types") List<PostType> types,
+            @Param("threshold") LocalDateTime threshold,
+            Pageable pageable);
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
@@ -1,8 +1,10 @@
 package hansung.hansung_connect.domain.post.service;
 
 import hansung.hansung_connect.domain.post.dto.PostResponseDto;
+import hansung.hansung_connect.domain.post.dto.enums.PostQueryType;
 
 public interface PostQueryService {
 
     PostResponseDto.PostResponse getPost(Long userId, Long postId);
+    PostResponseDto.PostListResponse getPostsByType(PostQueryType type, int page);
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
@@ -6,11 +6,18 @@ import hansung.hansung_connect.domain.commnet.entity.Comment;
 import hansung.hansung_connect.domain.commnet.repository.CommentRepository;
 import hansung.hansung_connect.domain.post.converter.PostConverter;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostListResponse;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostResponse;
+import hansung.hansung_connect.domain.post.dto.enums.PostQueryType;
 import hansung.hansung_connect.domain.post.entity.Post;
+import hansung.hansung_connect.domain.post.entity.enums.PostType;
 import hansung.hansung_connect.domain.post.repository.PostRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,12 +26,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PostQueryServiceImpl implements PostQueryService {
 
+    private static final int PAGE_SIZE = 20;
+
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
     private final PostConverter postConverter;
 
     @Override
     public PostResponse getPost(Long userId, Long postId) {
+
+        //TODO: 조회수 증가 로직 필요
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
@@ -36,5 +47,80 @@ public class PostQueryServiceImpl implements PostQueryService {
                 .toList();
 
         return postConverter.toPostResponse(post, userId, commentResponses);
+    }
+
+    @Override
+    public PostListResponse getPostsByType(PostQueryType type, int page) {
+        Page<Post> posts;
+
+        switch (type) {
+            case PostQueryType.POPULAR:
+                posts = getPopularPosts(page);
+                break;
+            case PostQueryType.FREE:
+                posts = getFreePosts(page);
+                break;
+            case PostQueryType.PROMOTION:
+                posts = getPromotionPosts(page);
+                break;
+            case PostQueryType.NOTICE:
+                posts = getNoticePosts(page);
+                break;
+            default:
+                throw new GeneralException(ErrorStatus.POST_QUERY_TYPE_EXCEPTION);
+        }
+
+        if(posts == null) {
+            throw new GeneralException(ErrorStatus.POST_LIST_NOT_FOUND);
+        }
+
+        return postConverter.toPostListResponse(posts);
+    }
+
+    private Page<Post> getPopularPosts(int page) {
+
+        if(page != 0) {
+            throw new GeneralException(ErrorStatus.INVALID_PAGE_FOR_POPULAR);
+        }
+
+        LocalDateTime threshold = LocalDateTime.now().minusHours(24);
+
+        Page<Post> posts = postRepository.findPopularPostsInLast24Hours(
+                List.of(PostType.FREE, PostType.PROMOTION),
+                threshold,
+                PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "views"))
+        );
+
+        return posts;
+    }
+
+    private Page<Post> getFreePosts(int page) {
+
+        Page<Post> posts = postRepository.findByType(
+                PostType.FREE,
+                PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
+        return posts;
+    }
+
+    private Page<Post> getPromotionPosts(int page) {
+
+        Page<Post> posts = postRepository.findByType(
+                PostType.PROMOTION,
+                PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
+        return posts;
+    }
+
+    private Page<Post> getNoticePosts(int page) {
+
+        Page<Post> posts = postRepository.findByType(
+                PostType.NOTICE,
+                PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
+        return posts;
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/entity/enums/AcademicStatus.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/entity/enums/AcademicStatus.java
@@ -1,9 +1,19 @@
 package hansung.hansung_connect.domain.user.entity.enums;
 
 public enum AcademicStatus {
-    ENROLLED,   //재학 중
-    GRADUATED,  //졸업
-    EXPECTED_GRADUATION,    //졸업 예정
-    COMPLETED,  //수료
-    LEAVE_OF_ABSENCE,   //휴학
+    ENROLLED("재학중"),   //재학 중
+    GRADUATED("졸업"),  //졸업
+    EXPECTED_GRADUATION("졸업예정"),    //졸업 예정
+    COMPLETED("수료"),  //수료
+    LEAVE_OF_ABSENCE("휴학");   //휴학
+
+    private final String status;
+
+    AcademicStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatus() {
+        return status;
+    }
 }


### PR DESCRIPTION
## 🔍 관련 이슈
#22

## 💡 주요 변경사항
게시글 리스트 조회 기능을 구현하였습니다.
- 인기 게시글 : 지난 24시간 동안 가장 많은 조회수 20개
- 자유 게시글 : 자유 게시판의 최신순 글 20개 (페이징 적용)
- 홍보 게시글 : 홍보 게시판의 최신순 글 20개 (페이징 적용)
- 공지 게시글 : 공지글 최신순 글 20개 (페이징 적용)

## 🎯 테스트 방법
1. 게시글 생성 
2. 스웨거 게시글 리스트 조회 api 테스트

## 🚨 논의하고 싶은 점
