### PR TITLE
[#24] 게시글 조회 시 조회수 증가

### DIFF
--- a/src/main/java/hansung/hansung_connect/domain/post/entity/Post.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/entity/Post.java
@@ -44,4 +44,8 @@ public class Post extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    public void increaseViews() {
+        views += 1;
+    }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
@@ -33,12 +33,13 @@ public class PostQueryServiceImpl implements PostQueryService {
     private final PostConverter postConverter;
 
     @Override
+    @Transactional
     public PostResponse getPost(Long userId, Long postId) {
-
-        //TODO: 조회수 증가 로직 필요
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        post.increaseViews();
 
         List<Comment> comments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId);
 


### PR DESCRIPTION
## 🔍 관련 이슈
#24

## 💡 주요 변경사항
게시글 단건 조회 API 호출 시 해당 게시글의 조회수가 1증가합니다.

## 🎯 테스트 방법
1. 게시글 단건 조회 API 호출
2. db에서 게시글의 조회수(views) 증가 확인

## 🚨 논의하고 싶은 점
