### PR TITLE
[#26] 나의 게시글 리스트 조회

### DIFF
--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -76,13 +76,20 @@ public class PostController {
 
     @Operation(
             summary = "내 게시글 리스트 조회",
-            description = "자신이 작성한 게시글의 리스트를 조회하는 API입니다."
+            description = """
+            작성한 게시글의 리스트를 조회하는 API입니다.
+            
+            한 페이지에 게시글의 수는 20입니다.
+            """
+
     )
     @GetMapping("/my")
     public ApiResponse<PostResponseDto.PostListResponse> getMyPosts(
-
+            @Parameter(description = "페이지 번호")
+            @RequestParam(defaultValue = "0") int page
     ) {
-        return ApiResponse.onSuccess(null);
+        Long userId = 1L;
+        return ApiResponse.onSuccess(postQueryService.getPostsByUser(userId, page));
     }
 
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/repository/PostRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/repository/PostRepository.java
@@ -21,4 +21,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             @Param("types") List<PostType> types,
             @Param("threshold") LocalDateTime threshold,
             Pageable pageable);
+
+    Page<Post> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
@@ -7,4 +7,5 @@ public interface PostQueryService {
 
     PostResponseDto.PostResponse getPost(Long userId, Long postId);
     PostResponseDto.PostListResponse getPostsByType(PostQueryType type, int page);
+    PostResponseDto.PostListResponse getPostsByUser(Long userId, int page);
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
@@ -12,6 +12,8 @@ import hansung.hansung_connect.domain.post.dto.enums.PostQueryType;
 import hansung.hansung_connect.domain.post.entity.Post;
 import hansung.hansung_connect.domain.post.entity.enums.PostType;
 import hansung.hansung_connect.domain.post.repository.PostRepository;
+import hansung.hansung_connect.domain.user.entity.User;
+import hansung.hansung_connect.domain.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
     private final PostConverter postConverter;
 
     @Override
@@ -124,4 +127,19 @@ public class PostQueryServiceImpl implements PostQueryService {
 
         return posts;
     }
+
+    @Override
+    public PostListResponse getPostsByUser(Long userId, int page) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Page<Post> posts = postRepository.findByUserId(
+                userId,
+                PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
+        return postConverter.toPostListResponse(posts);
+    }
+
 }


### PR DESCRIPTION
## 🔍 관련 이슈
#26

## 💡 주요 변경사항
나의 게시글 조회 API

## 🎯 테스트 방법
1. 스웨거 나의 게시글 조회 API 테스트

## 🚨 논의하고 싶은 점
회원가입, 로그인 기능이 추가되지 않아서 userId가 1인 게시글을 불러오게 되어 있습니다. 회원가입이 추가되면 수정하겠습니다.