### PR TITLE
[#30] 댓글 작성 API 구현

### DIFF
--- a/src/main/java/hansung/hansung_connect/domain/commnet/controller/CommentController.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/controller/CommentController.java
@@ -1,7 +1,9 @@
 package hansung.hansung_connect.domain.commnet.controller;
 
 import hansung.hansung_connect.common.response.ApiResponse;
+import hansung.hansung_connect.domain.commnet.dto.CommentRequestDto;
 import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto;
+import hansung.hansung_connect.domain.commnet.service.CommentCommandService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -9,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CommentController {
 
+    private final CommentCommandService commentCommandService;
+
     @Operation(
             summary = "댓글 작성",
             description = "댓글을 작성하는 API입니다. "
@@ -24,10 +29,11 @@ public class CommentController {
     @PostMapping("/posts/{postId}/comments")
     public ApiResponse<CommentResponseDto.CommentCreateResponse> createComment(
             @Parameter(description = "게시글 아이디", example = "1")
-            @PathVariable("postId") Long postId
+            @PathVariable("postId") Long postId,
+            @RequestBody CommentRequestDto.CommentCreateRequest request
     ) {
         Long userId = 1L;
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.onSuccess(commentCommandService.createComment(userId, postId, request));
     }
 
     @Operation(

--- a/src/main/java/hansung/hansung_connect/domain/commnet/converter/CommentConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/converter/CommentConverter.java
@@ -1,0 +1,26 @@
+package hansung.hansung_connect.domain.commnet.converter;
+
+import hansung.hansung_connect.domain.commnet.dto.CommentRequestDto;
+import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto;
+import hansung.hansung_connect.domain.commnet.entity.Comment;
+import hansung.hansung_connect.domain.post.entity.Post;
+import hansung.hansung_connect.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentConverter {
+
+    public Comment toComment(User user, Post post, CommentRequestDto.CommentCreateRequest request) {
+        return Comment.builder()
+                .body(request.getContent())
+                .user(user)
+                .post(post)
+                .build();
+    }
+
+    public CommentResponseDto.CommentCreateResponse toCommentCreateResponse(Comment comment) {
+        return CommentResponseDto.CommentCreateResponse.builder()
+                .commentId(comment.getId())
+                .build();
+    }
+}

--- a/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentCommandService.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentCommandService.java
@@ -1,0 +1,9 @@
+package hansung.hansung_connect.domain.commnet.service;
+
+import hansung.hansung_connect.domain.commnet.dto.CommentRequestDto;
+import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto;
+
+public interface CommentCommandService {
+
+    CommentResponseDto.CommentCreateResponse createComment(Long userId, Long postId, CommentRequestDto.CommentCreateRequest request);
+}

--- a/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentCommandServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentCommandServiceImpl.java
@@ -1,0 +1,42 @@
+package hansung.hansung_connect.domain.commnet.service;
+
+import hansung.hansung_connect.common.exception.GeneralException;
+import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
+import hansung.hansung_connect.domain.commnet.converter.CommentConverter;
+import hansung.hansung_connect.domain.commnet.dto.CommentRequestDto.CommentCreateRequest;
+import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto.CommentCreateResponse;
+import hansung.hansung_connect.domain.commnet.entity.Comment;
+import hansung.hansung_connect.domain.commnet.repository.CommentRepository;
+import hansung.hansung_connect.domain.post.entity.Post;
+import hansung.hansung_connect.domain.post.repository.PostRepository;
+import hansung.hansung_connect.domain.user.entity.User;
+import hansung.hansung_connect.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CommentCommandServiceImpl implements CommentCommandService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final CommentConverter commentConverter;
+
+    @Override
+    public CommentCreateResponse createComment(Long userId, Long postId, CommentCreateRequest request) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        Comment comment = commentConverter.toComment(user, post, request);
+        commentRepository.save(comment);
+
+        return commentConverter.toCommentCreateResponse(comment);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
#30

## 💡 주요 변경사항
댓글 작성 기능을 구현하였습니다.
- user 조회
- post 조회
- comment 생성

## 🎯 테스트 방법
1. 스웨거에서 댓글 작성 api 테스트

## 🚨 논의하고 싶은 점
회원가입, 로그인 기능 구현되면 userId = 1로 하드코딩된 부분 수정하겠습니다.