### PR TITLE
[#32] 내 댓글 리스트 조회 API 구현

### DIFF
--- a/src/main/java/hansung/hansung_connect/domain/commnet/controller/CommentController.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/controller/CommentController.java
@@ -4,6 +4,7 @@ import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.commnet.dto.CommentRequestDto;
 import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto;
 import hansung.hansung_connect.domain.commnet.service.CommentCommandService;
+import hansung.hansung_connect.domain.commnet.service.CommentQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommentController {
 
     private final CommentCommandService commentCommandService;
+    private final CommentQueryService commentQueryService;
 
     @Operation(
             summary = "댓글 작성",
@@ -50,7 +52,7 @@ public class CommentController {
             @RequestParam(defaultValue = "0") int page
     ) {
         Long userId = 1L;
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.onSuccess(commentQueryService.getCommentsByUser(userId, page));
     }
 
 

--- a/src/main/java/hansung/hansung_connect/domain/commnet/converter/CommentConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/converter/CommentConverter.java
@@ -5,6 +5,8 @@ import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto;
 import hansung.hansung_connect.domain.commnet.entity.Comment;
 import hansung.hansung_connect.domain.post.entity.Post;
 import hansung.hansung_connect.domain.user.entity.User;
+import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,6 +23,28 @@ public class CommentConverter {
     public CommentResponseDto.CommentCreateResponse toCommentCreateResponse(Comment comment) {
         return CommentResponseDto.CommentCreateResponse.builder()
                 .commentId(comment.getId())
+                .build();
+    }
+
+    public CommentResponseDto.CommentResponse toCommentResponse(Comment comment) {
+        return CommentResponseDto.CommentResponse.builder()
+                .commentId(comment.getId())
+                .commenter(comment.getUser().getName())
+                .studentId(comment.getUser().getStudentNumber())
+                .content(comment.getBody())
+                .build();
+    }
+
+    public CommentResponseDto.CommentListResponse toCommentListResponse(Page<Comment> commentPage) {
+        List<CommentResponseDto.CommentResponse> comments = commentPage.getContent().stream()
+                .map(this::toCommentResponse)
+                .toList();
+
+        return CommentResponseDto.CommentListResponse.builder()
+                .comments(comments)
+                .currentPage(commentPage.getNumber())
+                .hasNext(commentPage.hasNext())
+                .totalElements(commentPage.getTotalElements())
                 .build();
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/commnet/dto/CommentResponseDto.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/dto/CommentResponseDto.java
@@ -50,7 +50,7 @@ public class CommentResponseDto {
     public static class CommentResponse {
 
         @Schema(description = "댓글 ID", example = "123")
-        private Long CommentId;
+        private Long commentId;
 
         @Schema(description = "댓글 작성자", example = "장우진")
         private String commenter;

--- a/src/main/java/hansung/hansung_connect/domain/commnet/repository/CommentRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/repository/CommentRepository.java
@@ -2,8 +2,13 @@ package hansung.hansung_connect.domain.commnet.repository;
 
 import hansung.hansung_connect.domain.commnet.entity.Comment;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
     List<Comment> findByPostIdOrderByCreatedAtAsc(Long postId);
+
+    Page<Comment> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentQueryService.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentQueryService.java
@@ -1,0 +1,8 @@
+package hansung.hansung_connect.domain.commnet.service;
+
+import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto;
+
+public interface CommentQueryService {
+
+    CommentResponseDto.CommentListResponse getCommentsByUser(Long userId, int page);
+}

--- a/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentQueryServiceImpl.java
@@ -1,0 +1,40 @@
+package hansung.hansung_connect.domain.commnet.service;
+
+import hansung.hansung_connect.common.exception.GeneralException;
+import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
+import hansung.hansung_connect.domain.commnet.converter.CommentConverter;
+import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto.CommentListResponse;
+import hansung.hansung_connect.domain.commnet.entity.Comment;
+import hansung.hansung_connect.domain.commnet.repository.CommentRepository;
+import hansung.hansung_connect.domain.user.entity.User;
+import hansung.hansung_connect.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentQueryServiceImpl implements CommentQueryService {
+
+    private static final int PAGE_SIZE = 20;
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final CommentConverter commentConverter;
+
+    @Override
+    public CommentListResponse getCommentsByUser(Long userId, int page) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Page<Comment> comments = commentRepository.findByUserId(
+                userId,
+                PageRequest.of(page, PAGE_SIZE, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
+        return commentConverter.toCommentListResponse(comments);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
#32

## 💡 주요 변경사항
내 댓글 리스트 조회 API를 구현하였습니다.

## 🎯 테스트 방법
1. 스웨거에서 댓글 작성 api 테스트

## 🚨 논의하고 싶은 점
회원가입, 로그인 기능 구현되면 userId = 1로 하드코딩된 부분 수정하겠습니다.