### PR TITLE
[#20] Feat: 카카오 로그인, 온보딩, 로그아웃 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.6'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'hansung'
@@ -9,35 +9,42 @@ version = '0.0.1-SNAPSHOT'
 description = 'A project submitted to the Hansung University Idea Competition'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-  implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
-	//jpa
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	runtimeOnly("com.mysql:mysql-connector-j")
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    //jpa
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    runtimeOnly("com.mysql:mysql-connector-j")
+    // Kakao WebClient
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    // JWT (jjwt)
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/hansung/hansung_connect/auth/controller/AuthController.java
+++ b/src/main/java/hansung/hansung_connect/auth/controller/AuthController.java
@@ -1,0 +1,77 @@
+package hansung.hansung_connect.auth.controller;
+
+import hansung.hansung_connect.auth.dto.LoginRequest;
+import hansung.hansung_connect.auth.dto.LoginResponse;
+import hansung.hansung_connect.auth.dto.LogoutRequest;
+import hansung.hansung_connect.auth.dto.OnboardingRequest;
+import hansung.hansung_connect.auth.service.AuthService;
+import hansung.hansung_connect.auth.token.JwtAuthFilter.SimpleUserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "카카오 로그인, 계정 관련 API")
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @Operation(
+            summary = "카카오 로그인",
+            description = """
+                    카카오 access_token 을 받아 서버 로그인을 진행합니다.
+                    - 현재 provider는 "kakao"로 통일 (확장성 고려)
+                    - 성공 시 한성커넥트 서비스용 JWT(access/refresh) 를 발급
+                    - isNewUser, needsOnboarding으로 온보딩 필요여부 판단
+                    """
+    )
+    @PostMapping("/login")
+    public LoginResponse login(@RequestBody LoginRequest req) {
+        return authService.loginWithKakao(req.accessToken());
+    }
+
+    @Operation(
+            summary = "온보딩",
+            description = """
+                    JWT의 사용자 id로 사용자 식별 후, 온보딩 과정에서 받은 사용자정보를 저장합니다.
+                    - academicStatus ENUM
+                        - ENROLLED //재학 중
+                        - GRADUATED  //졸업
+                        - EXPECTED_GRADUATION    //졸업 예정
+                        - COMPLETED  //수료
+                        - LEAVE_OF_ABSENCE   //휴학""",
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/onboarding")
+    public void onboarding(
+            @Parameter(hidden = true) @AuthenticationPrincipal SimpleUserPrincipal me,
+            @RequestBody OnboardingRequest req) {
+        authService.onboarding(me.id(), req);
+    }
+
+    @Operation(
+            summary = "로그아웃",
+            description = """
+                    서버에 저장된 RefreshToken을 폐기합니다.
+                    - Body에 로그인 응답에서 받은 refreshToken을 전달
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @PostMapping("/logout")
+    public void logout(
+            @Parameter(hidden = true) @AuthenticationPrincipal SimpleUserPrincipal me,
+            @RequestBody LogoutRequest req) {
+        authService.logout(me.id(), req.refreshToken());
+    }
+}
+
+

--- a/src/main/java/hansung/hansung_connect/auth/dto/LoginRequest.java
+++ b/src/main/java/hansung/hansung_connect/auth/dto/LoginRequest.java
@@ -1,0 +1,5 @@
+package hansung.hansung_connect.auth.dto;
+
+public record LoginRequest(String provider, String accessToken) {
+}
+

--- a/src/main/java/hansung/hansung_connect/auth/dto/LoginResponse.java
+++ b/src/main/java/hansung/hansung_connect/auth/dto/LoginResponse.java
@@ -1,0 +1,9 @@
+package hansung.hansung_connect.auth.dto;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        boolean isNewUser,
+        boolean needsOnboarding
+) {
+}

--- a/src/main/java/hansung/hansung_connect/auth/dto/LogoutRequest.java
+++ b/src/main/java/hansung/hansung_connect/auth/dto/LogoutRequest.java
@@ -1,0 +1,5 @@
+package hansung.hansung_connect.auth.dto;
+
+public record LogoutRequest(String refreshToken) {
+}
+

--- a/src/main/java/hansung/hansung_connect/auth/dto/OnboardingRequest.java
+++ b/src/main/java/hansung/hansung_connect/auth/dto/OnboardingRequest.java
@@ -1,0 +1,16 @@
+package hansung.hansung_connect.auth.dto;
+
+import hansung.hansung_connect.domain.user.entity.enums.AcademicStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OnboardingRequest {
+    private String name;
+    private String major;
+    private String studentNumber;
+    private AcademicStatus academicStatus;
+    private boolean jobSeeking;
+    private boolean mentor;
+}

--- a/src/main/java/hansung/hansung_connect/auth/kakao/KakaoClient.java
+++ b/src/main/java/hansung/hansung_connect/auth/kakao/KakaoClient.java
@@ -1,0 +1,21 @@
+package hansung.hansung_connect.auth.kakao;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoClient {
+    private final WebClient kakaoWebClient;
+
+    public KakaoUserDto getUser(String kakaoAccessToken) {
+        return kakaoWebClient.get()
+                .uri("/v2/user/me")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
+                .retrieve()
+                .bodyToMono(KakaoUserDto.class)
+                .block();
+    }
+}

--- a/src/main/java/hansung/hansung_connect/auth/kakao/KakaoUserDto.java
+++ b/src/main/java/hansung/hansung_connect/auth/kakao/KakaoUserDto.java
@@ -1,0 +1,9 @@
+package hansung.hansung_connect.auth.kakao;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoUserDto {
+    private Long id;
+}
+

--- a/src/main/java/hansung/hansung_connect/auth/kakao/KakaoWebClientConfig.java
+++ b/src/main/java/hansung/hansung_connect/auth/kakao/KakaoWebClientConfig.java
@@ -1,0 +1,16 @@
+package hansung.hansung_connect.auth.kakao;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class KakaoWebClientConfig {
+    @Bean
+    public WebClient kakaoWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://kapi.kakao.com")
+                .build();
+    }
+}
+

--- a/src/main/java/hansung/hansung_connect/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/hansung/hansung_connect/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package hansung.hansung_connect.auth.repository;
+
+import hansung.hansung_connect.auth.token.RefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByToken(String token);
+
+    void deleteAllByUser_Id(Long userId);
+}

--- a/src/main/java/hansung/hansung_connect/auth/service/AuthService.java
+++ b/src/main/java/hansung/hansung_connect/auth/service/AuthService.java
@@ -1,0 +1,72 @@
+package hansung.hansung_connect.auth.service;
+
+import hansung.hansung_connect.auth.dto.LoginResponse;
+import hansung.hansung_connect.auth.dto.OnboardingRequest;
+import hansung.hansung_connect.auth.kakao.KakaoClient;
+import hansung.hansung_connect.auth.kakao.KakaoUserDto;
+import hansung.hansung_connect.auth.repository.RefreshTokenRepository;
+import hansung.hansung_connect.auth.token.RefreshToken;
+import hansung.hansung_connect.auth.token.TokenProvider;
+import hansung.hansung_connect.domain.user.entity.User;
+import hansung.hansung_connect.domain.user.repository.UserRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoClient kakaoClient;
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public LoginResponse loginWithKakao(String kakaoAccessToken) {
+        KakaoUserDto ku = kakaoClient.getUser(kakaoAccessToken);
+
+        User user = userRepository.findByKakaoUserId(ku.getId())
+                .orElseGet(() -> userRepository.save(
+                        User.fromKakao(
+                                ku.getId()
+                        )
+                ));
+
+        // 카카오 프로필 최신화(선택)
+        user.updateKakaoProfile(ku.getId());
+
+        boolean isNewUser = !user.isOnboarded()
+                && user.getName() == null
+                && user.getMajor() == null;
+
+        String access = tokenProvider.createAccessToken(user.getId());
+        String refresh = tokenProvider.createRefreshToken(user.getId());
+
+        // 기존 refresh 전부 정리(선택) 후 새 토큰 저장
+        refreshTokenRepository.deleteAllByUser_Id(user.getId());
+        refreshTokenRepository.save(RefreshToken.builder()
+                .token(refresh)
+                .user(user)
+                .expiresAt(Instant.now().plus(14, ChronoUnit.DAYS))
+                .build());
+
+        return new LoginResponse(access, refresh, isNewUser, !user.isOnboarded());
+    }
+
+    @Transactional
+    public void onboarding(Long userId, OnboardingRequest req) {
+        User user = userRepository.findById(userId).orElseThrow();
+        user.completeOnboarding(
+                req.getName(), req.getMajor(), req.getStudentNumber(),
+                req.getAcademicStatus(), req.isJobSeeking(), req.isMentor()
+        );
+    }
+
+    @Transactional
+    public void logout(Long userId, String refreshToken) {
+        refreshTokenRepository.deleteByToken(refreshToken);
+    }
+}

--- a/src/main/java/hansung/hansung_connect/auth/token/JwtAuthFilter.java
+++ b/src/main/java/hansung/hansung_connect/auth/token/JwtAuthFilter.java
@@ -1,0 +1,47 @@
+package hansung.hansung_connect.auth.token;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws ServletException, IOException {
+
+        String header = req.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            String jwt = header.substring(7);
+            if (tokenProvider.validate(jwt)) {
+                Long userId = tokenProvider.getUserId(jwt);
+                // 간단한 인증 토큰 (권한 필요 없으면 ROLE_USER 1개)
+                Authentication auth = new UsernamePasswordAuthenticationToken(
+                        new SimpleUserPrincipal(userId),
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                );
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+        chain.doFilter(req, res);
+    }
+
+    // 컨트롤러에서 @AuthenticationPrincipal 로 꺼낼 프린시펄
+    public record SimpleUserPrincipal(Long id) {
+    }
+}
+

--- a/src/main/java/hansung/hansung_connect/auth/token/RefreshToken.java
+++ b/src/main/java/hansung/hansung_connect/auth/token/RefreshToken.java
@@ -1,0 +1,49 @@
+package hansung.hansung_connect.auth.token;
+
+import hansung.hansung_connect.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refresh_tokens", indexes = {
+        @Index(name = "ix_refresh_token_user", columnList = "user_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 512)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private Instant expiresAt;
+
+    public boolean isExpired() {
+        return Instant.now().isAfter(expiresAt);
+    }
+}
+

--- a/src/main/java/hansung/hansung_connect/auth/token/TokenProvider.java
+++ b/src/main/java/hansung/hansung_connect/auth/token/TokenProvider.java
@@ -20,7 +20,7 @@ public class TokenProvider {
     private final long accessTtlMinutes;
     private final long refreshTtlDays;
 
-    // 단 하나의 생성자만 사용 (필수)
+    // 단 하나의 생성자만 사용
     public TokenProvider(
             @Value("${app.jwt.secret}") String secret,
             @Value("${app.jwt.access-ttl-minutes:60}") long accessTtlMinutes,

--- a/src/main/java/hansung/hansung_connect/auth/token/TokenProvider.java
+++ b/src/main/java/hansung/hansung_connect/auth/token/TokenProvider.java
@@ -1,0 +1,76 @@
+package hansung.hansung_connect.auth.token;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenProvider {
+
+    private final SecretKey key;
+    private final long accessTtlMinutes;
+    private final long refreshTtlDays;
+
+    // 단 하나의 생성자만 사용 (필수)
+    public TokenProvider(
+            @Value("${app.jwt.secret}") String secret,
+            @Value("${app.jwt.access-ttl-minutes:60}") long accessTtlMinutes,
+            @Value("${app.jwt.refresh-ttl-days:14}") long refreshTtlDays
+    ) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTtlMinutes = accessTtlMinutes;
+        this.refreshTtlDays = refreshTtlDays;
+    }
+
+    public String createAccessToken(Long userId) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plus(accessTtlMinutes, ChronoUnit.MINUTES)))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim("typ", "refresh")
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(now.plus(refreshTtlDays, ChronoUnit.DAYS)))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Long getUserId(String jwt) {
+        Claims c = Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(jwt).getBody();
+        return Long.valueOf(c.getSubject());
+    }
+
+    public boolean isRefreshToken(String jwt) {
+        Claims c = Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(jwt).getBody();
+        Object typ = c.get("typ");
+        return "refresh".equals(typ);
+    }
+
+    public boolean validate(String jwt) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(jwt);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/hansung/hansung_connect/config/SecurityConfig.java
+++ b/src/main/java/hansung/hansung_connect/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package hansung.hansung_connect.config;
+
+import hansung.hansung_connect.auth.token.JwtAuthFilter;
+import hansung.hansung_connect.auth.token.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/auth/login",
+                                "/auth/debug/**",
+                                "/swagger-ui/**", "/v3/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}
+

--- a/src/main/java/hansung/hansung_connect/domain/user/entity/User.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/entity/User.java
@@ -10,54 +10,100 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "users")
+@Table(
+        name = "users",
+        indexes = {
+                @Index(name = "ux_users_kakao_user_id", columnList = "kakao_user_id", unique = true),
+                @Index(name = "ix_users_status", columnList = "status")
+        }
+)
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@EqualsAndHashCode(of = "id", callSuper = false)
 public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 10, nullable = false, unique = true)
+    // Kakao
+    @Column(name = "kakao_user_id", nullable = false, unique = true)
+    private Long kakaoUserId;
+
+    // 온보딩 flag
+    @Column(name = "onboarded", nullable = false)
+    private boolean onboarded = false;
+
+    // 서비스 도메인 (온보딩으로 채움)
+    @Column(name = "student_number", length = 10, unique = true)
     private String studentNumber;
 
-    @Column(length = 50, nullable = false)
+    @Column(name = "name", length = 50)
     private String name;
 
-    @Column(length = 50, nullable = false)
+    @Column(name = "major", length = 50)
     private String major;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private AcademicStatus academicStatus;      //재학 상태
+    @Column(name = "academic_status", length = 30, nullable = true)
+    private AcademicStatus academicStatus;
 
-    @Column(nullable = false)
-    private boolean isJobSeeking;    //구직 상태
+    @Column(name = "job_seeking")
+    private boolean jobSeeking;
 
-    @Column(nullable = false)
-    private boolean isMentor;
+    @Column(name = "mentor")
+    private boolean mentor;
 
-    private String profileImage;
-
-    private String introduction;
-
-    @Builder.Default
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "status", nullable = false, length = 20)
     private UserStatus status = UserStatus.ACTIVATE;
 
+    @Column(name = "deactivated_at", nullable = true)
     private LocalDateTime deactivatedAt;
+
+    // 최초 카카오 로그인 시 사용
+    public static User fromKakao(Long kakaoUserId) {
+        User u = new User();
+        u.kakaoUserId = kakaoUserId;
+        u.onboarded = false;
+        u.status = UserStatus.ACTIVATE;
+        return u;
+    }
+
+    public void updateKakaoProfile(Long kakaoUserId) {
+        this.kakaoUserId = kakaoUserId; // 안전상 재할당
+    }
+
+    public void completeOnboarding(String name,
+                                   String major,
+                                   String studentNumber,
+                                   AcademicStatus status,
+                                   boolean jobSeeking,
+                                   boolean mentor) {
+        this.name = name;
+        this.major = major;
+        this.studentNumber = studentNumber;
+        this.academicStatus = status;
+        this.jobSeeking = jobSeeking;
+        this.mentor = mentor;
+        this.onboarded = true;
+    }
+
+    // 탈퇴,비활성화
+    public void deactivate() {
+        this.status = UserStatus.DEACTIVATE;
+        this.deactivatedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/repository/UserRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/repository/UserRepository.java
@@ -1,7 +1,11 @@
 package hansung.hansung_connect.domain.user.repository;
 
 import hansung.hansung_connect.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByKakaoUserId(Long kakaoUserId);
+
+    boolean existsByStudentNumber(String studentNumber);
 }

--- a/src/main/java/hansung/hansung_connect/test/TestController.java
+++ b/src/main/java/hansung/hansung_connect/test/TestController.java
@@ -1,18 +1,26 @@
 package hansung.hansung_connect.test;
 
+import hansung.hansung_connect.auth.kakao.KakaoClient;
+import hansung.hansung_connect.auth.kakao.KakaoUserDto;
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.test.dto.TestResponse;
 import hansung.hansung_connect.test.dto.TestResponse.TestDTO;
 import hansung.hansung_connect.test.service.TestQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Test", description = "테스트용 API")
+@Profile({"local", "dev"})
 @RestController
 @RequestMapping("/test")
 @RequiredArgsConstructor
@@ -30,8 +38,45 @@ public class TestController {
             description = "Query String으로 전달된 flag 값이 1일 경우 예외를 발생시키는 테스트용 API입니다."
     )
     @GetMapping("/exception")
-    public ApiResponse<TestResponse.ExceptionDTO> exceptionAPI(@RequestParam Integer flag){
+    public ApiResponse<TestResponse.ExceptionDTO> exceptionAPI(@RequestParam Integer flag) {
         testQueryService.CheckFlag(flag);
         return ApiResponse.onSuccess(TestConverter.toExceptionDTO(flag));
+    }
+
+    @Operation(
+            summary = "카카오 인가 코드 콜백 (테스트)",
+            description = """
+                    카카오 로그인 승인 후 카카오가 리다이렉트하는 콜백 엔드포인트입니다.
+                    프런트/로컬 테스트용으로 code 값을 눈으로 확인할 때만 사용하세요.
+                    실제 서비스 로그인 플로우에서는 사용하지 않습니다.
+                    """
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "인가 코드가 정상적으로 수신됨")
+    @GetMapping("kakao/callback")
+    public ResponseEntity<String> callback(
+            @Parameter(
+                    description = "카카오가 전달하는 인가 코드(authorization code)",
+                    example = "IABcdEFgH-12xyZ......"
+            )
+            @RequestParam("code") String code
+    ) {
+        return ResponseEntity.ok("code=" + code); // 인가 코드 확인용
+    }
+
+    private final KakaoClient kakaoClient;
+
+    @Operation(
+            summary = "카카오 /v2/user/me 디버그 호출",
+            description = """
+                    프런트(또는 카카오 테스트 페이지)에서 받은 카카오 access_token으로
+                    카카오 사용자 정보를 직접 조회해보는 디버그용 API입니다.
+                    - 운영 환경에서는 노출/사용 금지
+                    - 정상 토큰인지, 어떤 필드가 넘어오는지 빠르게 검증할 때 사용
+                    """
+    )
+    @PostMapping("/kakao/me")
+    public KakaoUserDto debugKakaoMe(@org.springframework.web.bind.annotation.RequestBody Map<String, String> body) {
+        String accessToken = body.get("accessToken");
+        return kakaoClient.getUser(accessToken);
     }
 }

--- a/src/main/java/hansung/hansung_connect/test/TestController.java
+++ b/src/main/java/hansung/hansung_connect/test/TestController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Test", description = "테스트용 API")
-@Profile({"local", "dev"})
+// @Profile({"local", "dev"}) // 개발 완료 시 이 줄 활성화
 @RestController
 @RequestMapping("/test")
 @RequiredArgsConstructor


### PR DESCRIPTION
## 🔍 관련 이슈 
#20

## 💡 주요 변경사항 
카카오 로그인 기능 전반을 구현하였습니다.
모바일 앱(안드로이드)에서 전달받은 Kakao Access Token을 사용하여 신규 사용자 생성 및 기존 사용자 로그인 처리를 수행합니다.
또한, 온보딩 정보 입력 및 로그아웃 로직을 포함하여 사용자 세션 관리 전반을 완성하였습니다.
- KakaoClient를 통해 https://kapi.kakao.com/v2/user/me API 연동
- 신규 사용자 생성(User.fromKakao) 및 기존 사용자 갱신 로직 구현
- JWT Access/Refresh Token 발급 및 저장소(refresh_tokens) 관리
- /auth/login, /auth/onboarding, /auth/logout API 컨트롤러 구현
- Swagger 명세 추가 및 예외처리 구조 통합
- User 엔티티의 필드 nullable 구조 개선 및 카카오 로그인용 정적 팩토리 메서드 추가

## 🎯 테스트 방법 
1. 인가 코드(code) 받기
브라우저 주소창에 아래 <REST_API_KEY>를 채워 입력
https://kauth.kakao.com/oauth/authorize?client_id=<REST_API_KEY>&redirect_uri=http://localhost:8080/dev/kakao/callback&response_type=code
2. URL 끝에 붙은 인가 코드 받고, code → access_token 교환
(간단히 cmd열고 아래 명령어로 테스트)

```
curl -X POST "https://kauth.kakao.com/oauth/token" -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=authorization_code" -d "client_id=<REST_API_KEY>" -d "redirect_uri=http://localhost:8080/dev/kakao/callback" -d "code=<위에서_복사한_code>"
```
3. 반환되는 accessTocken을 이용하여 우리서버에 로그인, 아래와 같이 성공응답확인 (스웨거로 테스트)
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e00c437e-5b68-471a-84f0-90051e666c05" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8c3aaf9c-0339-44bd-818f-ac4cefbe8888" />
4. 로그인 성공응답의 바디에 있는 accessTocken을 아래 스웨거 JWT TOKEN에 입력, Authorize.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7170b56a-d8c8-451d-a9fa-943efae6145e" />    

6. 온보딩 api를 활용하여 테스트 (스웨거)

7. 온보딩 성공 후 로그아웃 api 활용하여 테스트(스웨거)


## 🚨 논의하고 싶은 점 
없습니다!