### PR TITLE
[#37] Feat: 내 커리어 여러개 일괄 추가 API 구현

### DIFF
--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
@@ -37,7 +37,8 @@ public enum ErrorStatus implements BaseErrorCode {
     CAREER_INVALID_YEARMONTH_FORMAT(HttpStatus.BAD_REQUEST, "CAREER4005", "연월 형식이 올바르지 않습니다. (예: 2024-04)"),
     CAREER_END_YM_FORBIDDEN_WHEN_EMPLOYED(HttpStatus.BAD_REQUEST, "CAREER4006", "재직중이면 종료 연월을 입력할 수 없습니다."),
     CAREER_END_YM_REQUIRED_WHEN_NOT_EMPLOYED(HttpStatus.BAD_REQUEST, "CAREER4007", "재직중이 아니면 종료 연월이 필요합니다."),
-    CAREER_END_YM_BEFORE_START(HttpStatus.BAD_REQUEST, "CAREER4008", "종료 연월은 시작 연월보다 앞설 수 없습니다.");
+    CAREER_END_YM_BEFORE_START(HttpStatus.BAD_REQUEST, "CAREER4008", "종료 연월은 시작 연월보다 앞설 수 없습니다."),
+    CAREER_BULK_EMPTY(HttpStatus.BAD_REQUEST, "CAREER4009", "추가할 커리어 항목이 비어 있습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/hansung/hansung_connect/domain/career/controller/CareerController.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/controller/CareerController.java
@@ -2,6 +2,7 @@ package hansung.hansung_connect.domain.career.controller;
 
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.career.dto.CareerRequestDTO;
+import hansung.hansung_connect.domain.career.dto.CareerRequestDTO.BatchCreateRequestDTO;
 import hansung.hansung_connect.domain.career.dto.CareerResponseDTO;
 import hansung.hansung_connect.domain.career.service.CareerCommandService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,6 +42,24 @@ public class CareerController {
         return ApiResponse.onSuccess(response);
     }
 
-
+    @Operation(
+            summary = "내 커리어 여러 개 일괄 추가",
+            description = """
+                    온보딩 등에서 커리어를 **여러 개 한 번에 등록**하는 API입니다.<br>
+                    - items 배열에 단건 생성 스펙과 동일한 객체들을 담아 전송합니다.<br>
+                    - startYm, endYm 형식: "yyyy-MM" 또는 "yyyy.MM" (둘 다 허용)<br>
+                    - 재직 중(employed == true)이면 endYm은 null이어야 합니다.<br><br>
+                    <b>JobType ENUM</b><br>
+                    • PERMANENT (정규직)<br>
+                    • TEMPORARY (계약직)<br>
+                    • INTERN (인턴)<br>
+                    • FREELANCER (프리랜서)
+                    """
+    )
+    @PostMapping("/users/me/careers/batch")
+    public ApiResponse<CareerResponseDTO.BulkCreateResponseDTO> createCareers(
+            @RequestBody BatchCreateRequestDTO requestDTO) {
+        return ApiResponse.onSuccess(careerCommandService.createCareers(requestDTO));
+    }
 }
 

--- a/src/main/java/hansung/hansung_connect/domain/career/converter/CareerConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/converter/CareerConverter.java
@@ -1,10 +1,13 @@
 package hansung.hansung_connect.domain.career.converter;
 
+import hansung.hansung_connect.domain.career.dto.CareerRequestDTO;
 import hansung.hansung_connect.domain.career.dto.CareerRequestDTO.CreateRequestDTO;
+import hansung.hansung_connect.domain.career.dto.CareerResponseDTO;
 import hansung.hansung_connect.domain.career.dto.CareerResponseDTO.CreateResponseDTO;
 import hansung.hansung_connect.domain.career.entity.Career;
 import hansung.hansung_connect.domain.user.entity.User;
 import java.time.YearMonth;
+import java.util.List;
 import lombok.Builder;
 import org.springframework.stereotype.Component;
 
@@ -33,6 +36,27 @@ public class CareerConverter {
                 .employed(career.isEmployed())
                 .startYm(formatYm(career.getStartYm()))
                 .endYm(formatYmNullable(career.getEndYm()))
+                .build();
+    }
+
+    // ===== 배치 변환 =====
+    public List<Career> toEntities(List<CareerRequestDTO.CreateRequestDTO> items, User user) {
+        return items.stream()
+                .map(dto -> toEntity(dto, user))
+                .toList();
+    }
+
+    public List<CreateResponseDTO> toCreateResponseDTOList(List<Career> careers) {
+        return careers.stream()
+                .map(this::toResponseDTO)
+                .toList();
+    }
+
+    public CareerResponseDTO.BulkCreateResponseDTO toBulkCreateResponseDTO(List<Career> saved) {
+        List<CareerResponseDTO.CreateResponseDTO> list = toCreateResponseDTOList(saved);
+        return CareerResponseDTO.BulkCreateResponseDTO.builder()
+                .careers(list)
+                .createdCount(list.size())
                 .build();
     }
 

--- a/src/main/java/hansung/hansung_connect/domain/career/dto/CareerRequestDTO.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/dto/CareerRequestDTO.java
@@ -2,6 +2,7 @@ package hansung.hansung_connect.domain.career.dto;
 
 import hansung.hansung_connect.domain.career.entity.enums.JobType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,6 +32,15 @@ public class CareerRequestDTO {
 
         @Schema(description = "재직 여부", example = "true")
         private boolean employed;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "CareerBulkCreateRequest", title = "커리어 일괄 등록 요청")
+    public static class BatchCreateRequestDTO {
+
+        @Schema(description = "등록할 커리어 목록")
+        private List<CreateRequestDTO> items;
     }
 
 }

--- a/src/main/java/hansung/hansung_connect/domain/career/dto/CareerResponseDTO.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/dto/CareerResponseDTO.java
@@ -2,6 +2,7 @@ package hansung.hansung_connect.domain.career.dto;
 
 import hansung.hansung_connect.domain.career.entity.enums.JobType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -36,6 +37,20 @@ public class CareerResponseDTO {
 
         @Schema(description = "근무 종료 연월 (재직중이면 null)", example = "2024-08")
         private String endYm;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "CareerBulkCreateResponse", title = "커리어 일괄 등록 응답")
+    public static class BulkCreateResponseDTO {
+
+        @Schema(description = "생성된 커리어 목록")
+        private List<CreateResponseDTO> careers;
+
+        @Schema(description = "생성된 개수", example = "3")
+        private int createdCount;
     }
 }
 

--- a/src/main/java/hansung/hansung_connect/domain/career/service/CareerCommandService.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/service/CareerCommandService.java
@@ -1,9 +1,12 @@
 package hansung.hansung_connect.domain.career.service;
 
 import hansung.hansung_connect.domain.career.dto.CareerRequestDTO;
+import hansung.hansung_connect.domain.career.dto.CareerRequestDTO.BatchCreateRequestDTO;
 import hansung.hansung_connect.domain.career.dto.CareerResponseDTO;
 
 public interface CareerCommandService {
     CareerResponseDTO.CreateResponseDTO createCareer(CareerRequestDTO.CreateRequestDTO requestDTO);
+
+    CareerResponseDTO.BulkCreateResponseDTO createCareers(BatchCreateRequestDTO requestDTO);
 }
 

--- a/src/main/java/hansung/hansung_connect/domain/career/service/CareerCommandServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/service/CareerCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package hansung.hansung_connect.domain.career.service;
 
+import static hansung.hansung_connect.common.exception.code.status.ErrorStatus.CAREER_BULK_EMPTY;
 import static hansung.hansung_connect.common.exception.code.status.ErrorStatus.CAREER_COMPANY_REQUIRED;
 import static hansung.hansung_connect.common.exception.code.status.ErrorStatus.CAREER_END_YM_BEFORE_START;
 import static hansung.hansung_connect.common.exception.code.status.ErrorStatus.CAREER_END_YM_FORBIDDEN_WHEN_EMPLOYED;
@@ -13,12 +14,14 @@ import static hansung.hansung_connect.common.exception.code.status.ErrorStatus.U
 import hansung.hansung_connect.common.exception.GeneralException;
 import hansung.hansung_connect.domain.career.converter.CareerConverter;
 import hansung.hansung_connect.domain.career.dto.CareerRequestDTO;
+import hansung.hansung_connect.domain.career.dto.CareerRequestDTO.BatchCreateRequestDTO;
 import hansung.hansung_connect.domain.career.dto.CareerResponseDTO;
 import hansung.hansung_connect.domain.career.entity.Career;
 import hansung.hansung_connect.domain.career.repository.CareerRepository;
 import hansung.hansung_connect.domain.user.entity.User;
 import hansung.hansung_connect.domain.user.repository.UserRepository;
 import java.time.YearMonth;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,15 +39,34 @@ public class CareerCommandServiceImpl implements CareerCommandService {
     public CareerResponseDTO.CreateResponseDTO createCareer(CareerRequestDTO.CreateRequestDTO requestDTO) {
         validateBusiness(requestDTO);
 
-        Long currentUserId = 1L; // TODO: SecurityContext로 교체
+        Long currentUserId = 1L; // TODO: 추후 SecurityContext로 교체
         User user = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
 
         Career saved = careerRepository.save(careerConverter.toEntity(requestDTO, user));
-        return careerConverter.toResponseDTO(saved); // ← 이 메서드도 이너 DTO 반환하도록 수정(아래 2번)
+        return careerConverter.toResponseDTO(saved);
     }
 
-    // 도메인 규칙 검증
+    @Override
+    public CareerResponseDTO.BulkCreateResponseDTO createCareers(BatchCreateRequestDTO requestDTO) {
+        if (requestDTO == null || requestDTO.getItems() == null || requestDTO.getItems().isEmpty()) {
+            throw new GeneralException(CAREER_BULK_EMPTY);
+        }
+
+        // 각 항목 검증
+        requestDTO.getItems().forEach(this::validateBusiness);
+
+        Long currentUserId = 1L; // TODO: 추후 SecurityContext로 교체
+        User user = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
+
+        List<Career> toSave = careerConverter.toEntities(requestDTO.getItems(), user);
+        List<Career> saved = careerRepository.saveAll(toSave);
+
+        return careerConverter.toBulkCreateResponseDTO(saved);
+    }
+
+    // ===== 도메인 규칙 검증 (단건/배치 공용) =====
     private void validateBusiness(CareerRequestDTO.CreateRequestDTO dto) {
         if (dto.getCompanyName() == null || dto.getCompanyName().isBlank()) {
             throw new GeneralException(CAREER_COMPANY_REQUIRED);
@@ -59,7 +81,6 @@ public class CareerCommandServiceImpl implements CareerCommandService {
             throw new GeneralException(CAREER_START_YM_REQUIRED);
         }
 
-        // 월 포맷 검증 (".", "-" 모두 허용)
         YearMonth start = parseYm(dto.getStartYm());
         YearMonth end = dto.isEmployed() ? null : parseYmNullable(dto.getEndYm());
 
@@ -78,8 +99,7 @@ public class CareerCommandServiceImpl implements CareerCommandService {
 
     private YearMonth parseYm(String raw) {
         try {
-            String n = raw.replace('.', '-');
-            return YearMonth.parse(n);
+            return YearMonth.parse(raw.replace('.', '-').trim());
         } catch (Exception e) {
             throw new GeneralException(CAREER_INVALID_YEARMONTH_FORMAT);
         }
@@ -90,77 +110,10 @@ public class CareerCommandServiceImpl implements CareerCommandService {
             return null;
         }
         try {
-            return YearMonth.parse(raw.replace('.', '-'));
+            return YearMonth.parse(raw.replace('.', '-').trim());
         } catch (Exception e) {
             throw new GeneralException(CAREER_INVALID_YEARMONTH_FORMAT);
         }
     }
 }
 
-//@Service
-//@RequiredArgsConstructor
-//@Transactional
-//public class CareerCommandServiceImpl implements CareerCommandService {
-//
-//    private final CareerRepository careerRepository;
-//    private final CareerConverter careerConverter;
-//    private final UserRepository userRepository; // /users/me 이므로 인증 사용자 로드
-//
-//    @Override
-//    public CareerResponseDTO createCareer(CareerRequestDTO requestDTO) {
-//        validateBusiness(requestDTO);
-//
-//        // TODO: 추후 SecurityContext에서 현재 로그인 사용자 ID 추출하도록 교체
-//        Long currentUserId = 1L; // 임시
-//        User user = userRepository.findById(currentUserId)
-//                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-//
-//        Career saved = careerRepository.save(careerConverter.toEntity(requestDTO, user));
-//        return careerConverter.toResponseDTO(saved);
-//    }
-//
-//    // ---- 도메인 규칙 검증 ----
-//    private void validateBusiness(CareerRequestDTO dto) {
-//        if (dto.getCompanyName() == null || dto.getCompanyName().isBlank()) {
-//            throw new IllegalArgumentException("회사명은 필수입니다.");
-//        }
-//        if (dto.getPosition() == null || dto.getPosition().isBlank()) {
-//            throw new IllegalArgumentException("직무명은 필수입니다.");
-//        }
-//        if (dto.getJobType() == null) {
-//            throw new IllegalArgumentException("재직 형태는 필수입니다.");
-//        }
-//        if (dto.getStartYm() == null || dto.getStartYm().isBlank()) {
-//            throw new IllegalArgumentException("근무 시작 연월은 필수입니다.");
-//        }
-//
-//        // 월 포맷 검증 (".", "-" 모두 허용)
-//        YearMonth start = parseYm(dto.getStartYm());
-//        YearMonth end = dto.isEmployed() ? null : parseYmNullable(dto.getEndYm());
-//
-//        if (dto.isEmployed() && dto.getEndYm() != null) {
-//            throw new IllegalArgumentException("재직중이면 종료 연월을 입력할 수 없습니다.");
-//        }
-//        if (!dto.isEmployed()) {
-//            if (end == null) {
-//                throw new IllegalArgumentException("재직중이 아니면 종료 연월이 필요합니다.");
-//            }
-//            if (end.isBefore(start)) {
-//                throw new IllegalArgumentException("종료 연월은 시작 연월보다 앞설 수 없습니다.");
-//            }
-//        }
-//    }
-//
-//    private YearMonth parseYm(String raw) {
-//        String n = raw.replace('.', '-');
-//        return YearMonth.parse(n);
-//    }
-//
-//    private YearMonth parseYmNullable(String raw) {
-//        if (raw == null || raw.isBlank()) {
-//            return null;
-//        }
-//        return YearMonth.parse(raw.replace('.', '-'));
-//    }
-//}
-//


### PR DESCRIPTION
## 🔍 관련 이슈
#37

## 💡 주요 변경사항
내 커리어 여러개 일괄 추가 기능(배치 추가)을 구현하였습니다. 내 커리어 배치 추가 API 호출 시 바디의 커리어 내용을 전부 DB에 저장하도록 했습니다.

## 🎯 테스트 방법
1. 스웨거에서 내 커리어 여러 개 일괄 추가 api ( POST users/me/careers/batch )테스트

## 🚨 논의하고 싶은 점
없습니다.