### PR TITLE
[#45] Feat: 마이페이지 화면 상단 사용자요약카드 조회 API 구현

### DIFF
--- a/src/main/java/hansung/hansung_connect/config/SecurityConfig.java
+++ b/src/main/java/hansung/hansung_connect/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                         // 개발 중 테스트할 API 임시 허용
                         .requestMatchers("/users/me/careers/**").permitAll()
                         .requestMatchers("/links/**").permitAll()
+                        .requestMatchers("/users/**").permitAll()
                         // 그 외는 인증 필요
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/hansung/hansung_connect/domain/career/repository/CareerRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/repository/CareerRepository.java
@@ -4,5 +4,6 @@ import hansung.hansung_connect.domain.career.entity.Career;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CareerRepository extends JpaRepository<Career, Long> {
+    boolean existsByUser_IdAndIsEmployedTrue(Long userId);
 }
 

--- a/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
@@ -1,0 +1,48 @@
+package hansung.hansung_connect.domain.user.controller;
+
+import hansung.hansung_connect.common.response.ApiResponse;
+import hansung.hansung_connect.domain.user.dto.UserResponseDTO;
+import hansung.hansung_connect.domain.user.dto.UserResponseDTO.SummaryCardResponse;
+import hansung.hansung_connect.domain.user.service.UserQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User", description = "유저/프로필 조회 API")
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserQueryService userQueryService;
+
+    @Operation(
+            summary = "마이페이지 상단 사용자요약카드",
+            description = """
+                    마이페이지 상단 카드에 필요한 최소 사용자 정보를 반환합니다.
+                    <br><br>
+                    필드 정보
+                    - studentNumberPrefix: 학번 앞 두 자리 (예: "21")  
+                    - major: 전공  
+                    - jobSeeking: 구직 여부 (구직중/구직중아님)
+                    - academicStatus: 학교관련 상태 
+                        - (ENROLLED:재학중/GRADUATED:졸업/EXPECTED_GRADUATION:졸업예정/COMPLETED:수료/LEAVE_OF_ABSENCE:휴학)
+                    - employed: 현재 재직상태 (재직중/재직중아님)
+                    """
+    )
+    @GetMapping("/summary")
+    public ResponseEntity<ApiResponse<SummaryCardResponse>> getMySummaryCard() {
+        // TODO: 실제 배포 시 SecurityContext에서 userId 추출
+        Long currentUserId = 1L;
+
+        UserResponseDTO.SummaryCardResponse result =
+                userQueryService.getMySummaryCard(currentUserId);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+}
+

--- a/src/main/java/hansung/hansung_connect/domain/user/converter/UserConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/converter/UserConverter.java
@@ -1,0 +1,32 @@
+package hansung.hansung_connect.domain.user.converter;
+
+import hansung.hansung_connect.domain.user.dto.UserResponseDTO;
+import hansung.hansung_connect.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserConverter {
+    public UserResponseDTO.SummaryCardResponse toSummaryCardResponse(User user, boolean employed) {
+        return UserResponseDTO.SummaryCardResponse.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .studentNumberPrefix(extractStudentNumberPrefix(user.getStudentNumber()))
+                .major(user.getMajor())
+                .jobSeeking(user.isJobSeeking())
+                .academicStatus(user.getAcademicStatus())
+                .employed(employed)
+                .build();
+    }
+
+    // 학번 앞 두 자리만 반환
+    private String extractStudentNumberPrefix(String studentNumber) {
+        if (studentNumber == null) {
+            return "";
+        }
+        String trimmed = studentNumber.trim();
+        if (trimmed.length() < 2) {
+            return "";
+        }
+        return trimmed.substring(0, 2);
+    }
+}

--- a/src/main/java/hansung/hansung_connect/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/dto/UserRequestDTO.java
@@ -1,0 +1,5 @@
+package hansung.hansung_connect.domain.user.dto;
+
+public class UserRequestDTO {
+    
+}

--- a/src/main/java/hansung/hansung_connect/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/dto/UserResponseDTO.java
@@ -1,0 +1,23 @@
+package hansung.hansung_connect.domain.user.dto;
+
+import hansung.hansung_connect.domain.user.entity.enums.AcademicStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserResponseDTO {
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class SummaryCardResponse {
+        private Long userId;                 // 사용자 PK
+        private String name;                 // 이름
+        private String studentNumberPrefix;  // 학번 앞 두 자리 (예: "21")
+        private String major;                // 전공
+        private boolean jobSeeking;          // 구직 여부
+        private AcademicStatus academicStatus; // 재학/졸업 등 상태
+        private boolean employed;            // 재직 중 여부 (Career.isEmployed 존재 여부)
+    }
+}

--- a/src/main/java/hansung/hansung_connect/domain/user/service/UserQueryService.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/service/UserQueryService.java
@@ -1,0 +1,7 @@
+package hansung.hansung_connect.domain.user.service;
+
+import hansung.hansung_connect.domain.user.dto.UserResponseDTO;
+
+public interface UserQueryService {
+    UserResponseDTO.SummaryCardResponse getMySummaryCard(Long currentUserId);
+}

--- a/src/main/java/hansung/hansung_connect/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/service/UserQueryServiceImpl.java
@@ -1,0 +1,34 @@
+package hansung.hansung_connect.domain.user.service;
+
+import hansung.hansung_connect.common.exception.GeneralException;
+import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
+import hansung.hansung_connect.domain.career.repository.CareerRepository;
+import hansung.hansung_connect.domain.user.converter.UserConverter;
+import hansung.hansung_connect.domain.user.dto.UserResponseDTO;
+import hansung.hansung_connect.domain.user.entity.User;
+import hansung.hansung_connect.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserQueryServiceImpl implements UserQueryService {
+
+    private final UserRepository userRepository;
+    private final CareerRepository careerRepository;
+    private final UserConverter userConverter;
+
+    @Override
+    public UserResponseDTO.SummaryCardResponse getMySummaryCard(Long currentUserId) {
+        User user = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 재직 여부 존재 검사 (Career에 isEmployed == true 인 레코드)
+        boolean employed = careerRepository.existsByUser_IdAndIsEmployedTrue(currentUserId);
+
+        return userConverter.toSummaryCardResponse(user, employed);
+    }
+}
+


### PR DESCRIPTION
## 🔍 관련 이슈
#45

## 💡 주요 변경사항
마이페이지 화면의 상단 사용자요약카드 조회 API를 구현하였습니다.

## 🎯 테스트 방법
1. 스웨거에서 마이페이지 화면의 상단 사용자요약카드 조회 api 테스트

## 🚨 논의하고 싶은 점
없습니다.