### PR TITLE
[#49] Feat: 내 프로필 수정 화면 기존정보 조회 API 구현

### DIFF
--- a/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
@@ -58,7 +58,7 @@ public class UserController {
             summary = "내 프로필 수정 화면(폼 채움용 기존정보)",
             description = """
                     프로필 수정 화면에 필요한 모든 기존값을 한 번에 반환합니다.
-                    - 기본정보: 학번, 이름, 전공, 멘토여부, 구직여부, 학사상태
+                    - 기본정보: 학번, 이름, 전공, 멘토여부, 구직여부, 재학상태
                     - 커리어 전체: id, companyName, position, jobType, employed, startYm, endYm
                     - 외부 링크 전체: id, type, url
                     """

--- a/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
@@ -1,14 +1,20 @@
 package hansung.hansung_connect.domain.user.controller;
 
 import hansung.hansung_connect.common.response.ApiResponse;
+import hansung.hansung_connect.domain.user.converter.UserConverter;
+import hansung.hansung_connect.domain.user.dto.UserRequestDTO;
 import hansung.hansung_connect.domain.user.dto.UserResponseDTO;
 import hansung.hansung_connect.domain.user.dto.UserResponseDTO.SummaryCardResponse;
+import hansung.hansung_connect.domain.user.service.UserCommandService;
 import hansung.hansung_connect.domain.user.service.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +25,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+
+    private final UserConverter userConverter;
 
     @Operation(
             summary = "마이페이지 상단 사용자요약카드",
@@ -60,6 +69,30 @@ public class UserController {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(userQueryService.getMyProfile(currentUserId))
         );
+    }
+
+    @Operation(
+            summary = "내 프로필(기본 정보) 부분수정",
+            description = """
+                    학번, 이름, 전공, 멘토참여여부, 구직여부만 부분 수정합니다.
+                    <br><br>
+                    - PATCH 이므로 전달된 필드만 반영합니다(null은 무시)  
+                    - 커리어/외부링크는 각 전용 API로 수정하세요.
+                    """
+    )
+    @PatchMapping("/myprofile")
+    public ResponseEntity<ApiResponse<Void>> updateMyBasicProfile(
+            @Valid @RequestBody UserRequestDTO.UpdateBasicProfileRequest request
+    ) {
+        Long currentUserId = 1L; // TODO: 인증 연동 후 SecurityContext에서 추출
+
+        // 입력 정규화(공백 제거 등)
+        UserRequestDTO.UpdateBasicProfileRequest normalized = userConverter.normalize(request);
+
+        // TODO: 실제 업데이트는 Command 서비스에서 처리 (예시)
+        userCommandService.updateMyBasicProfile(currentUserId, normalized);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }
 }
 

--- a/src/main/java/hansung/hansung_connect/domain/user/converter/UserConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/converter/UserConverter.java
@@ -2,6 +2,7 @@ package hansung.hansung_connect.domain.user.converter;
 
 import hansung.hansung_connect.domain.career.entity.Career;
 import hansung.hansung_connect.domain.link.entity.Link;
+import hansung.hansung_connect.domain.user.dto.UserRequestDTO;
 import hansung.hansung_connect.domain.user.dto.UserResponseDTO;
 import hansung.hansung_connect.domain.user.entity.User;
 import java.time.YearMonth;
@@ -76,5 +77,29 @@ public class UserConverter {
 
     private String formatYm(YearMonth ym) {
         return ym == null ? null : ym.format(YM_FORMAT);
+    }
+
+    public UserRequestDTO.UpdateBasicProfileRequest normalize(
+            UserRequestDTO.UpdateBasicProfileRequest req) {
+
+        if (req == null) {
+            return null;
+        }
+
+        return UserRequestDTO.UpdateBasicProfileRequest.builder()
+                .studentNumber(trimOrNull(req.getStudentNumber()))
+                .name(trimOrNull(req.getName()))
+                .major(trimOrNull(req.getMajor()))
+                .mentor(req.getMentor())
+                .jobSeeking(req.getJobSeeking())
+                .build();
+    }
+
+    private String trimOrNull(String s) {
+        if (s == null) {
+            return null;
+        }
+        String t = s.trim();
+        return t.isEmpty() ? null : t;
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/dto/UserRequestDTO.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/dto/UserRequestDTO.java
@@ -1,5 +1,37 @@
 package hansung.hansung_connect.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class UserRequestDTO {
-    
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class UpdateBasicProfileRequest {
+
+        @Schema(description = "학번", example = "2131114")
+        @Size(max = 10)
+        private String studentNumber;
+
+        @Schema(description = "이름", example = "아라치")
+        @Size(max = 50)
+        private String name;
+
+        @Schema(description = "전공", example = "회계재무경영")
+        @Size(max = 50)
+        private String major;
+
+        @Schema(description = "멘토 참여 여부", example = "true")
+        private Boolean mentor;
+
+        @Schema(description = "구직 여부", example = "true")
+        private Boolean jobSeeking;
+    }
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/entity/User.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/entity/User.java
@@ -106,4 +106,26 @@ public class User extends BaseEntity {
         this.deactivatedAt = LocalDateTime.now();
     }
 
+    public void updateBasicProfile(String studentNumber,
+                                   String name,
+                                   String major,
+                                   Boolean mentor,
+                                   Boolean jobSeeking) {
+        if (studentNumber != null) {
+            this.studentNumber = studentNumber;
+        }
+        if (name != null) {
+            this.name = name;
+        }
+        if (major != null) {
+            this.major = major;
+        }
+        if (mentor != null) {
+            this.mentor = mentor;
+        }
+        if (jobSeeking != null) {
+            this.jobSeeking = jobSeeking;
+        }
+    }
+
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/service/UserCommandService.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/service/UserCommandService.java
@@ -1,0 +1,7 @@
+package hansung.hansung_connect.domain.user.service;
+
+import hansung.hansung_connect.domain.user.dto.UserRequestDTO;
+
+public interface UserCommandService {
+    void updateMyBasicProfile(Long currentUserId, UserRequestDTO.UpdateBasicProfileRequest request);
+}

--- a/src/main/java/hansung/hansung_connect/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/service/UserCommandServiceImpl.java
@@ -1,0 +1,39 @@
+package hansung.hansung_connect.domain.user.service;
+
+import hansung.hansung_connect.common.exception.GeneralException;
+import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
+import hansung.hansung_connect.domain.user.dto.UserRequestDTO;
+import hansung.hansung_connect.domain.user.entity.User;
+import hansung.hansung_connect.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserCommandServiceImpl implements UserCommandService {
+    private final UserRepository userRepository;
+
+    @Override
+    public void updateMyBasicProfile(Long currentUserId,
+                                     UserRequestDTO.UpdateBasicProfileRequest request) {
+
+        // 1) 본인 계정 조회
+        User user = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 2) 부분수정 적용 (null 미반영)
+        user.updateBasicProfile(
+                request.getStudentNumber(),
+                request.getName(),
+                request.getMajor(),
+                request.getMentor(),
+                request.getJobSeeking()
+        );
+
+        // 3) JPA dirty checking으로 update 반영 (명시 save 불필요)
+        // 필요 시 명시 저장:
+        // userRepository.save(user);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
#49

## 💡 주요 변경사항
내 프로필 수정 화면 부분수정(커리어,링크 제외) API를 구현하였습니다.

## 🎯 테스트 방법
1. 내 프로필 수정 화면 부분수정(커리어,링크 제외) API 테스트

## 🚨 논의하고 싶은 점
없습니다.