### PR TITLE
[#51] Feat: 한성인 찾기 (멘토조회) API 구현

### DIFF
--- a/src/main/java/hansung/hansung_connect/domain/career/repository/CareerRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/repository/CareerRepository.java
@@ -1,13 +1,23 @@
 package hansung.hansung_connect.domain.career.repository;
 
 import hansung.hansung_connect.domain.career.entity.Career;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CareerRepository extends JpaRepository<Career, Long> {
     boolean existsByUser_IdAndIsEmployedTrue(Long userId);
 
     List<Career> findAllByUser_Id(Long userId);
 
+    @Query("""
+            select distinct c.user.id
+            from Career c
+            where c.user.id in :userIds
+              and c.isEmployed = true
+            """)
+    List<Long> findUserIdsEmployedTrueIn(@Param("userIds") Collection<Long> userIds);
 }
 

--- a/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
@@ -97,7 +97,7 @@ public class UserController {
     }
 
     @Operation(
-            summary = "멘토 목록 조회 (전공 우선, 15개/페이지)",
+            summary = "멘토 목록 조회 (전공 우선 정렬, 15개/페이지)",
             description = """
                     로그인 사용자와 같은 전공인 멘토 우선정렬하여 보여집니다.<br><br>
                     페이징: page(기본 0), size(기본 15)<br>

--- a/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User", description = "유저/프로필 조회 API")
@@ -93,6 +94,33 @@ public class UserController {
         userCommandService.updateMyBasicProfile(currentUserId, normalized);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    @Operation(
+            summary = "멘토 목록 조회 (전공 우선, 15개/페이지)",
+            description = """
+                    로그인 사용자와 같은 전공인 멘토 우선정렬하여 보여집니다.<br><br>
+                    페이징: page(기본 0), size(기본 15)<br>
+                    반환 필드:
+                    - totalMentorCount: 전체 멘토 수
+                    - items: 멘토 카드 리스트
+                    """
+    )
+    @GetMapping("/mentors")
+    public ResponseEntity<ApiResponse<UserResponseDTO.MentorListResponse>> getMentors(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "15") int size
+    ) {
+        // 개발 단계: 하드코딩. 추후 SecurityContext에서 꺼내기
+        Long currentUserId = 1L;
+
+        // 강제 size=15 정책 사용 시 고정
+        // size = 15;
+
+        UserResponseDTO.MentorListResponse result =
+                userQueryService.getMentors(currentUserId, page, size);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 }
 

--- a/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
@@ -97,7 +97,7 @@ public class UserController {
     }
 
     @Operation(
-            summary = "멘토 목록 조회 (전공 우선 정렬, 15개/페이지)",
+            summary = "한성인 찾기(멘토 목록 조회) (전공 우선 정렬, 15개/페이지)",
             description = """
                     로그인 사용자와 같은 전공인 멘토 우선정렬하여 보여집니다.<br><br>
                     페이징: page(기본 0), size(기본 15)<br>

--- a/src/main/java/hansung/hansung_connect/domain/user/converter/UserConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/converter/UserConverter.java
@@ -8,7 +8,9 @@ import hansung.hansung_connect.domain.user.entity.User;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -101,5 +103,28 @@ public class UserConverter {
         }
         String t = s.trim();
         return t.isEmpty() ? null : t;
+    }
+
+    public UserResponseDTO.MentorListResponse toMentorListResponse(
+            Page<User> page, Set<Long> employedUserIds, long totalMentorCount) {
+
+        List<UserResponseDTO.MentorCard> cards = page.getContent().stream()
+                .map(u -> UserResponseDTO.MentorCard.builder()
+                        .userId(u.getId())
+                        .name(u.getName())
+                        .major(u.getMajor())
+                        .jobSeeking(u.isJobSeeking())
+                        .employed(employedUserIds.contains(u.getId()))
+                        .academicStatus(u.getAcademicStatus())
+                        .build())
+                .collect(Collectors.toList());
+
+        return UserResponseDTO.MentorListResponse.builder()
+                .totalMentorCount(totalMentorCount)
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalPages(page.getTotalPages())
+                .items(cards)
+                .build();
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/dto/UserResponseDTO.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/dto/UserResponseDTO.java
@@ -63,4 +63,29 @@ public class UserResponseDTO {
         private LinkType type;
         private String url;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MentorCard {
+        private Long userId;
+        private String name;
+        private String major;
+        private boolean jobSeeking;
+        private boolean employed;
+        private AcademicStatus academicStatus; // 재학/졸업 여부 표현
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class MentorListResponse {
+        private long totalMentorCount;   // 전체 멘토 수(필터/전공 무관, mentor=true & 활성)
+        private int page;                // 0-based
+        private int size;                // 요청한 페이지 크기(기본 15)
+        private int totalPages;
+        private List<MentorCard> items;  // 카드 15개
+    }
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/repository/UserRepository.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/repository/UserRepository.java
@@ -1,11 +1,31 @@
 package hansung.hansung_connect.domain.user.repository;
 
 import hansung.hansung_connect.domain.user.entity.User;
+import hansung.hansung_connect.domain.user.entity.enums.UserStatus;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoUserId(Long kakaoUserId);
 
     boolean existsByStudentNumber(String studentNumber);
+
+    Optional<User> findById(Long id);
+
+    long countByMentorTrueAndStatus(UserStatus status);
+
+    @Query("""
+            select u
+            from User u
+            where u.mentor = true
+              and u.status = :status
+            order by case when u.major = :major then 0 else 1 end, u.id desc
+            """)
+    Page<User> findMentorsOrderByMajorPreference(@Param("major") String major,
+                                                 @Param("status") UserStatus status,
+                                                 Pageable pageable);
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/service/UserQueryService.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/service/UserQueryService.java
@@ -6,4 +6,7 @@ public interface UserQueryService {
     UserResponseDTO.SummaryCardResponse getMySummaryCard(Long currentUserId);
 
     UserResponseDTO.MyProfileResponse getMyProfile(Long currentUserId);
+
+    UserResponseDTO.MentorListResponse getMentors(Long currentUserId, int page, int size);
+
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/service/UserQueryServiceImpl.java
@@ -9,9 +9,15 @@ import hansung.hansung_connect.domain.link.repository.LinkRepository;
 import hansung.hansung_connect.domain.user.converter.UserConverter;
 import hansung.hansung_connect.domain.user.dto.UserResponseDTO;
 import hansung.hansung_connect.domain.user.entity.User;
+import hansung.hansung_connect.domain.user.entity.enums.UserStatus;
 import hansung.hansung_connect.domain.user.repository.UserRepository;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +51,24 @@ public class UserQueryServiceImpl implements UserQueryService {
         List<Link> links = linkRepository.findAllByUser_Id(currentUserId);
 
         return userConverter.toMyProfileResponse(user, careers, links);
+    }
+
+    @Override
+    public UserResponseDTO.MentorListResponse getMentors(Long currentUserId, int page, int size) {
+        User me = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        String myMajor = me.getMajor();
+
+        long totalMentorCount = userRepository.countByMentorTrueAndStatus(UserStatus.ACTIVATE);
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<User> mentorPage = userRepository.findMentorsOrderByMajorPreference(
+                myMajor, UserStatus.ACTIVATE, pageable);
+
+        List<Long> userIds = mentorPage.map(User::getId).getContent();
+        Set<Long> employedUserIds = new HashSet<>(careerRepository.findUserIdsEmployedTrueIn(userIds));
+        
+        return userConverter.toMentorListResponse(mentorPage, employedUserIds, totalMentorCount);
     }
 }
 


### PR DESCRIPTION
## 🔍 관련 이슈
#51

## 💡 주요 변경사항
한성인 찾기 (멘토조회) API를 구현하였습니다.
- 한성인 찾기 (멘토조회) API 호출 시 멘토 목록 반환
- 로그인 사용자와 같은 전공인 멘토 우선정렬하여 반환
- 화면 상단의 전체 멘토 수도 포함하여 반환
- 페이징: page(기본 0), size(기본 15)

## 🎯 테스트 방법
1. 스웨거에서 한성인 찾기 (멘토조회) API 테스트

## 🚨 논의하고 싶은 점
없습니다.