### PR TITLE
[#65] Feat: 온보딩 API에 누락된 이메일 필드를 추가

### DIFF
--- a/src/main/java/hansung/hansung_connect/auth/dto/OnboardingRequest.java
+++ b/src/main/java/hansung/hansung_connect/auth/dto/OnboardingRequest.java
@@ -13,4 +13,5 @@ public class OnboardingRequest {
     private AcademicStatus academicStatus;
     private boolean jobSeeking;
     private boolean mentor;
+    private String email;
 }

--- a/src/main/java/hansung/hansung_connect/auth/service/AuthService.java
+++ b/src/main/java/hansung/hansung_connect/auth/service/AuthService.java
@@ -61,7 +61,7 @@ public class AuthService {
         User user = userRepository.findById(userId).orElseThrow();
         user.completeOnboarding(
                 req.getName(), req.getMajor(), req.getStudentNumber(),
-                req.getAcademicStatus(), req.isJobSeeking(), req.isMentor()
+                req.getAcademicStatus(), req.isJobSeeking(), req.isMentor(), req.getEmail()
         );
     }
 

--- a/src/main/java/hansung/hansung_connect/domain/user/entity/User.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/entity/User.java
@@ -93,7 +93,7 @@ public class User extends BaseEntity {
                                    String studentNumber,
                                    AcademicStatus status,
                                    boolean jobSeeking,
-                                   boolean mentor) {
+                                   boolean mentor, String email) {
         this.name = name;
         this.major = major;
         this.studentNumber = studentNumber;
@@ -101,6 +101,7 @@ public class User extends BaseEntity {
         this.jobSeeking = jobSeeking;
         this.mentor = mentor;
         this.onboarded = true;
+        this.email = email;
     }
 
     // 탈퇴,비활성화


### PR DESCRIPTION
## 🔍 관련 이슈
#65

## 💡 주요 변경사항
- 온보딩 요청dto에 이메일 필드 추가
- 컨버터에 이메일 필드 추가할 곳에 전부 추가함.
- 그외 서비스부분 이메일 필드 추가
- 더 누락된 필드 있는지 확인했으나 없었음.

## 🎯 테스트 방법
1. 스웨거에서 온보딩 API 테스트

## 🚨 논의하고 싶은 점
없습니다.


