### PR TITLE
[#68] 메인화면 인기 게시글 조회 API

### DIFF
--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -91,4 +91,16 @@ public class PostController {
         return ApiResponse.onSuccess(postQueryService.getPostsByUser(userId, page));
     }
 
+    @GetMapping("/popular")
+    @Operation(
+            summary = "메인화면 - 인기 게시글 조회",
+            description = """
+                    메인화면에서 인기 게시글 5개의 제목을 제공합니다.
+                    인기 게시글: 지난 24시간 동안 조회 수가 가장 높은 게시글
+                    """
+    )
+    public ApiResponse<PostResponseDto.PostTitleListResponse> getPopularPosts() {
+        return ApiResponse.onSuccess(postQueryService.getPopularPosts());
+    }
+
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
@@ -82,4 +82,21 @@ public class PostConverter {
                 .totalElements(postPage.getTotalElements())
                 .build();
     }
+
+    public PostResponseDto.PostTitleListResponse toPostTitleListResponse(Page<Post> postPage) {
+        List<PostResponseDto.PostTitleResponse> posts = postPage.getContent().stream()
+                .map(this::toPostTitleResponse)
+                .toList();
+
+        return PostResponseDto.PostTitleListResponse.builder()
+                .posts(posts)
+                .build();
+    }
+
+    public PostResponseDto.PostTitleResponse toPostTitleResponse(Post post) {
+        return PostResponseDto.PostTitleResponse.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .build();
+    }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
@@ -119,4 +119,29 @@ public class PostResponseDto {
         private boolean mine;
 
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "PostTitleListResponse", title = "게시글의 제목 리스트 응답")
+    public static class PostTitleListResponse {
+        @Schema(description = "게시글 ID", example = "123")
+        private List<PostTitleResponse> posts;
+
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(name = "PostTitleResponse", title = "게시글의 제목 응답")
+    public static class PostTitleResponse {
+        @Schema(description = "게시글 ID", example = "123")
+        private Long id;
+
+        @Schema(description = "게시글 제목", example = "실시간 심장병 질문 1위")
+        private String title;
+
+    }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
@@ -8,4 +8,5 @@ public interface PostQueryService {
     PostResponseDto.PostResponse getPost(Long userId, Long postId);
     PostResponseDto.PostListResponse getPostsByType(PostQueryType type, int page);
     PostResponseDto.PostListResponse getPostsByUser(Long userId, int page);
+    PostResponseDto.PostTitleListResponse getPopularPosts();
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
@@ -8,6 +8,7 @@ import hansung.hansung_connect.domain.post.converter.PostConverter;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostListResponse;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostResponse;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostTitleListResponse;
 import hansung.hansung_connect.domain.post.dto.enums.PostQueryType;
 import hansung.hansung_connect.domain.post.entity.Post;
 import hansung.hansung_connect.domain.post.entity.enums.PostType;
@@ -29,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostQueryServiceImpl implements PostQueryService {
 
     private static final int PAGE_SIZE = 20;
+    private static final int MAIN_POPULAR_POST_SIZE = 5;
 
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
@@ -98,6 +100,23 @@ public class PostQueryServiceImpl implements PostQueryService {
         return posts;
     }
 
+    private Page<Post> getPopularPosts(int page, int size) {
+
+        if(page != 0) {
+            throw new GeneralException(ErrorStatus.INVALID_PAGE_FOR_POPULAR);
+        }
+
+        LocalDateTime threshold = LocalDateTime.now().minusHours(24);
+
+        Page<Post> posts = postRepository.findPopularPostsInLast24Hours(
+                List.of(PostType.FREE, PostType.PROMOTION),
+                threshold,
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "views"))
+        );
+
+        return posts;
+    }
+
     private Page<Post> getFreePosts(int page) {
 
         Page<Post> posts = postRepository.findByType(
@@ -142,4 +161,12 @@ public class PostQueryServiceImpl implements PostQueryService {
         return postConverter.toPostListResponse(posts);
     }
 
+    @Override
+    public PostTitleListResponse getPopularPosts() {
+
+        Page<Post> posts;
+        posts = getPopularPosts(0, MAIN_POPULAR_POST_SIZE);
+
+        return postConverter.toPostTitleListResponse(posts);
+    }
 }


### PR DESCRIPTION
## 🔍 관련 이슈
#68

## 💡 주요 변경사항
- 인기 게시글 5개의 제목과 아이디 조회하는 기능 추가

## 🎯 테스트 방법
1. 스웨거에서 인기 게시글 조회 API 테스트

## 🚨 논의하고 싶은 점



