### PR TITLE
[#70] 메인화면 최신 홍보 게시글 조회

### DIFF
--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -103,4 +103,14 @@ public class PostController {
         return ApiResponse.onSuccess(postQueryService.getPopularPosts());
     }
 
+    @GetMapping("/promotion")
+    @Operation(
+            summary = "메인화면 - 최신 홍보 게시글 조회",
+            description = """
+                    메인화면에서 최신 홍보 게시글 5개의 요약 응답을 제공합니다.
+                    """
+    )
+    public ApiResponse<PostResponseDto.PostSummaryListResponse> getLatestPromotionPosts() {
+        return ApiResponse.onSuccess(postQueryService.getLatestPromotionPosts());
+    }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
@@ -70,6 +70,16 @@ public class PostConverter {
                 .build();
     }
 
+    public PostResponseDto.PostSummaryListResponse toPostSummaryListResponse(Page<Post> postPage) {
+        List<PostResponseDto.PostSummaryResponse> posts = postPage.getContent().stream()
+                .map(this::toPostSummaryResponse)
+                .toList();
+
+        return PostResponseDto.PostSummaryListResponse.builder()
+                .posts(posts)
+                .build();
+    }
+
     public PostResponseDto.PostListResponse toPostListResponse(Page<Post> postPage) {
         List<PostResponseDto.PostSummaryResponse> posts = postPage.getContent().stream()
                 .map(this::toPostSummaryResponse)

--- a/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
@@ -50,6 +50,16 @@ public class PostResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    @Schema(name = "PostSummaryListResponse", title = "게시글의 요약 정보 리스트 응답")
+    public static class PostSummaryListResponse {
+        @Schema(description = "게시글 ID", example = "123")
+        private List<PostSummaryResponse> posts;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Schema(name = "PostListResponse", title = "게시글 목록 조회 응답")
     public static class PostListResponse {
         @Schema(description = "게시글 요약 정보")

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryService.java
@@ -9,4 +9,5 @@ public interface PostQueryService {
     PostResponseDto.PostListResponse getPostsByType(PostQueryType type, int page);
     PostResponseDto.PostListResponse getPostsByUser(Long userId, int page);
     PostResponseDto.PostTitleListResponse getPopularPosts();
+    PostResponseDto.PostSummaryListResponse getLatestPromotionPosts();
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostQueryServiceImpl.java
@@ -8,6 +8,7 @@ import hansung.hansung_connect.domain.post.converter.PostConverter;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostListResponse;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostResponse;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostSummaryListResponse;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostTitleListResponse;
 import hansung.hansung_connect.domain.post.dto.enums.PostQueryType;
 import hansung.hansung_connect.domain.post.entity.Post;
@@ -30,7 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostQueryServiceImpl implements PostQueryService {
 
     private static final int PAGE_SIZE = 20;
-    private static final int MAIN_POPULAR_POST_SIZE = 5;
+    private static final int MAIN_PAGE_POST_SIZE = 5;
 
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
@@ -137,6 +138,16 @@ public class PostQueryServiceImpl implements PostQueryService {
         return posts;
     }
 
+    private Page<Post> getPromotionPosts(int page, int size) {
+
+        Page<Post> posts = postRepository.findByType(
+                PostType.PROMOTION,
+                PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"))
+        );
+
+        return posts;
+    }
+
     private Page<Post> getNoticePosts(int page) {
 
         Page<Post> posts = postRepository.findByType(
@@ -165,8 +176,17 @@ public class PostQueryServiceImpl implements PostQueryService {
     public PostTitleListResponse getPopularPosts() {
 
         Page<Post> posts;
-        posts = getPopularPosts(0, MAIN_POPULAR_POST_SIZE);
+        posts = getPopularPosts(0, MAIN_PAGE_POST_SIZE);
 
         return postConverter.toPostTitleListResponse(posts);
+    }
+
+    @Override
+    public PostSummaryListResponse getLatestPromotionPosts() {
+
+         Page<Post> posts;
+         posts = getPromotionPosts(0, MAIN_PAGE_POST_SIZE);
+
+         return postConverter.toPostSummaryListResponse(posts);
     }
 }


### PR DESCRIPTION
## 🔍 관련 이슈
#70

## 💡 주요 변경사항
메인화면에서 최신 홍보 게시글을 조회하는 기능을 추가

## 🎯 테스트 방법
1. 스웨거에서 메인화면 최신 홍보 게시글 조회 테스트

## 🚨 논의하고 싶은 점
