### PR TITLE
[#72] 게시글 수정 API

### DIFF
--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
@@ -26,8 +26,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 게시글 관련 응답
     POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST4001", "게시글을 찾을 수 없습니다."),
     POST_QUERY_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "POST4002", "게시글 조회 타입이 잘못되었습니다."),
-    POST_LIST_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "POST5001", "게시글 리스트가 비어있습니다."),
-    INVALID_PAGE_FOR_POPULAR(HttpStatus.BAD_REQUEST, "POST4003", "인기 게시글은 0번 페이지만 조회 가능합니다."),
+    POST_LIST_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "POST4003", "게시글 리스트가 비어있습니다."),
+    INVALID_PAGE_FOR_POPULAR(HttpStatus.BAD_REQUEST, "POST4004", "인기 게시글은 0번 페이지만 조회 가능합니다."),
+    POST_FORBIDDEN(HttpStatus.INTERNAL_SERVER_ERROR, "POST4005", "해당 게시글의 수정이 허용된 사용자가 아닙니다."),
 
     // 커리어 관련 응답
     CAREER_COMPANY_REQUIRED(HttpStatus.BAD_REQUEST, "CAREER4001", "회사명은 필수입니다."),

--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -112,5 +113,24 @@ public class PostController {
     )
     public ApiResponse<PostResponseDto.PostSummaryListResponse> getLatestPromotionPosts() {
         return ApiResponse.onSuccess(postQueryService.getLatestPromotionPosts());
+    }
+
+    @PatchMapping("/{postId}")
+    @Operation(
+            summary = "게시글 수정",
+            description = """
+                    게시글을 수정하는 API입니다. 제목, 내용 중 수정된 부분만 전달
+                    -title: 게시글 제목, null 허용
+                    -body: 게시글 내용 , null 허용
+                    """
+    )
+    public ApiResponse<PostResponseDto.PostUpdateResponse> updatePost(
+            @PathVariable("postId") Long postId,
+            @RequestBody PostRequestDto.PostUpdateRequest request
+    ) {
+
+        Long userId = 1L;
+
+        return ApiResponse.onSuccess(postCommandService.updatePost(userId, postId, request));
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/converter/PostConverter.java
@@ -31,6 +31,12 @@ public class PostConverter {
                 .build();
     }
 
+    public PostResponseDto.PostUpdateResponse toPostUpdateResponse(Post post) {
+        return PostResponseDto.PostUpdateResponse.builder()
+                .postId(post.getId())
+                .build();
+    }
+
     public PostResponseDto.PostResponse toPostResponse(Post post, Long currentUserId, List<PostCommentResponse> commentResponses) {
         return PostResponseDto.PostResponse.builder()
                 .id(post.getId())

--- a/src/main/java/hansung/hansung_connect/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/dto/PostRequestDto.java
@@ -21,4 +21,16 @@ public class PostRequestDto {
         @Schema(description = "게시글 본문", example = "한성대에서 채용 공고가 올라왔습니다.")
         private String body;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(name = "PostUpdateRequest", title = "게시글 수정 요청")
+    public static class PostUpdateRequest {
+
+        @Schema(description = "게시글 제목", example = "한성대 채용 공고")
+        private String title;
+
+        @Schema(description = "게시글 본문", example = "한성대에서 채용 공고가 올라왔습니다.")
+        private String body;
+    }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/dto/PostResponseDto.java
@@ -23,6 +23,18 @@ public class PostResponseDto {
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(name = "PostUpdateResponse", title = "게시글 수정 응답")
+    public static class PostUpdateResponse {
+
+        @Schema(description = "게시글 ID", example = "123")
+        private Long postId;
+
+    }
+
+    @Getter
+    @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     @Schema(name = "PostSummaryResponse", title = "게시글 요약 정보")

--- a/src/main/java/hansung/hansung_connect/domain/post/entity/Post.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/entity/Post.java
@@ -48,4 +48,12 @@ public class Post extends BaseEntity {
     public void increaseViews() {
         views += 1;
     }
+
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateBody(String body) {
+        this.body = body;
+    }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostCommandService.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostCommandService.java
@@ -5,4 +5,5 @@ import hansung.hansung_connect.domain.post.dto.PostResponseDto;
 
 public interface PostCommandService {
     PostResponseDto.PostCreateResponse createPost(Long userId, PostRequestDto.PostCreateRequest request);
+    PostResponseDto.PostUpdateResponse updatePost(Long userId, Long postId, PostRequestDto.PostUpdateRequest request);
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/service/PostCommandServiceImpl.java
@@ -4,7 +4,9 @@ import hansung.hansung_connect.common.exception.GeneralException;
 import hansung.hansung_connect.common.exception.code.status.ErrorStatus;
 import hansung.hansung_connect.domain.post.converter.PostConverter;
 import hansung.hansung_connect.domain.post.dto.PostRequestDto.PostCreateRequest;
+import hansung.hansung_connect.domain.post.dto.PostRequestDto.PostUpdateRequest;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostCreateResponse;
+import hansung.hansung_connect.domain.post.dto.PostResponseDto.PostUpdateResponse;
 import hansung.hansung_connect.domain.post.entity.Post;
 import hansung.hansung_connect.domain.post.repository.PostRepository;
 import hansung.hansung_connect.domain.user.entity.User;
@@ -31,6 +33,31 @@ public class PostCommandServiceImpl implements PostCommandService {
         Post post = postRepository.save(postConverter.toPost(user, request));
 
         return postConverter.toPostCreateResponse(post);
+    }
+
+    @Override
+    public PostUpdateResponse updatePost(Long userId, Long postId, PostUpdateRequest request) {
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.POST_NOT_FOUND));
+
+        if(!post.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.POST_FORBIDDEN);
+        }
+
+        String title = request.getTitle();
+        if(title != null) {
+            post.updateTitle(title);
+        }
+
+        String body = request.getTitle();
+        if(body != null) {
+            post.updateBody(body);
+        }
+
+        postRepository.save(post);
+
+        return postConverter.toPostUpdateResponse(post);
     }
 
 }


### PR DESCRIPTION
## 🔍 관련 이슈
#72

## 💡 주요 변경사항
게시글을 수정하는 기능을 추가
- 게시글 제목 수정
- 게시글 내용 수정

## 🎯 테스트 방법
1. 스웨거에서 게시글 수정 테스트

## 🚨 논의하고 싶은 점
