### PR TITLE
[#76] 댓글 삭제 API

### DIFF
--- a/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
+++ b/src/main/java/hansung/hansung_connect/common/exception/code/status/ErrorStatus.java
@@ -28,7 +28,11 @@ public enum ErrorStatus implements BaseErrorCode {
     POST_QUERY_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "POST4002", "게시글 조회 타입이 잘못되었습니다."),
     POST_LIST_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "POST4003", "게시글 리스트가 비어있습니다."),
     INVALID_PAGE_FOR_POPULAR(HttpStatus.BAD_REQUEST, "POST4004", "인기 게시글은 0번 페이지만 조회 가능합니다."),
-    POST_FORBIDDEN(HttpStatus.INTERNAL_SERVER_ERROR, "POST4005", "해당 게시글의 수정이 허용된 사용자가 아닙니다."),
+    POST_FORBIDDEN(HttpStatus.BAD_REQUEST, "POST4005", "해당 게시글의 권한이 없습니다."),
+
+    //댓글 관련 응답
+    COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST,"COMMENT4001","댓글을 찾을 수 없습니다."),
+    COMMENT_FORBIDDEN(HttpStatus.BAD_REQUEST,"COMMENT4002","해당 댓글의 권한이 없습니다."),
 
     // 커리어 관련 응답
     CAREER_COMPANY_REQUIRED(HttpStatus.BAD_REQUEST, "CAREER4001", "회사명은 필수입니다."),

--- a/src/main/java/hansung/hansung_connect/domain/commnet/controller/CommentController.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/controller/CommentController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,6 +56,23 @@ public class CommentController {
         return ApiResponse.onSuccess(commentQueryService.getCommentsByUser(userId, page));
     }
 
+    @Operation(
+            summary = "댓글 삭제",
+            description = """
+            댓글을 삭제하는 API입니다.
+            Path Variable로 댓글 아이디를 입력해주세요.
+            - 게시글의 작성자인 경우 모든 댓글 삭제 가능
+            - 게시글의 작성자가 아닌 경우 자신의 댓글만 삭제 가능
+            """
+    )
+    @DeleteMapping
+    public ApiResponse<Void> deleteComment(
+            @PathVariable("commentId") Long commentId
+    ) {
 
+        Long userId = 1L;
+        commentCommandService.deleteComment(userId, commentId);
+        return ApiResponse.onSuccess(null);
+    }
 
 }

--- a/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentCommandService.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentCommandService.java
@@ -6,4 +6,5 @@ import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto;
 public interface CommentCommandService {
 
     CommentResponseDto.CommentCreateResponse createComment(Long userId, Long postId, CommentRequestDto.CommentCreateRequest request);
+    void deleteComment(Long userId, Long commentId);
 }

--- a/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentCommandServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/service/CommentCommandServiceImpl.java
@@ -39,4 +39,20 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
         return commentConverter.toCommentCreateResponse(comment);
     }
+
+    @Override
+    public void deleteComment(Long userId, Long commentId) {
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+
+        User commentAuthor = comment.getUser();
+        User postAuthor = comment.getPost().getUser();
+
+        if(!commentAuthor.getId().equals(userId) && !postAuthor.getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.COMMENT_FORBIDDEN);
+        }
+
+        commentRepository.delete(comment);
+    }
 }


### PR DESCRIPTION
## 🔍 관련 이슈
#76

## 💡 주요 변경사항
댓글을 삭제하는 기능을 추가

## 🎯 테스트 방법
1. 스웨거에서 댓글 삭제 테스트

## 🚨 논의하고 싶은 점
