### PR TITLE
[#67]Feat: 계정탈퇴 API 구현완료 

### DIFF
--- a/src/main/java/hansung/hansung_connect/auth/controller/AuthController.java
+++ b/src/main/java/hansung/hansung_connect/auth/controller/AuthController.java
@@ -1,17 +1,22 @@
 package hansung.hansung_connect.auth.controller;
 
+import hansung.hansung_connect.auth.dto.AccountDeleteRequest;
+import hansung.hansung_connect.auth.dto.AccountDeleteResponse;
 import hansung.hansung_connect.auth.dto.LoginRequest;
 import hansung.hansung_connect.auth.dto.LoginResponse;
 import hansung.hansung_connect.auth.dto.LogoutRequest;
 import hansung.hansung_connect.auth.dto.OnboardingRequest;
 import hansung.hansung_connect.auth.service.AuthService;
 import hansung.hansung_connect.auth.token.JwtAuthFilter.SimpleUserPrincipal;
+import hansung.hansung_connect.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -71,6 +76,23 @@ public class AuthController {
             @Parameter(hidden = true) @AuthenticationPrincipal SimpleUserPrincipal me,
             @RequestBody LogoutRequest req) {
         authService.logout(me.id(), req.refreshToken());
+    }
+
+    @Operation(
+            summary = "계정 탈퇴",
+            description = """
+                    현재 로그인한 사용자의 계정을 삭제합니다.
+                    - 전달받은 refreshToken의 소유자가 본인인지 확인 후 진행
+                    - 사용자 레코드 삭제 및 해당 사용자의 모든 RefreshToken 삭제
+                    """,
+            security = @SecurityRequirement(name = "bearerAuth")
+    )
+    @DeleteMapping("/withdraw")
+    public ApiResponse<AccountDeleteResponse> withdraw(
+            @AuthenticationPrincipal SimpleUserPrincipal me,
+            @Valid @RequestBody AccountDeleteRequest req
+    ) {
+        return ApiResponse.onSuccess(authService.withdraw(me.id(), req));
     }
 }
 

--- a/src/main/java/hansung/hansung_connect/auth/converter/AuthConverter.java
+++ b/src/main/java/hansung/hansung_connect/auth/converter/AuthConverter.java
@@ -1,0 +1,14 @@
+package hansung.hansung_connect.auth.converter;
+
+import hansung.hansung_connect.auth.dto.AccountDeleteResponse;
+import java.time.Instant;
+
+public class AuthConverter {
+
+    private AuthConverter() {
+    }
+
+    public static AccountDeleteResponse toDeleteResponse(Long userId) {
+        return new AccountDeleteResponse(userId, Instant.now());
+    }
+}

--- a/src/main/java/hansung/hansung_connect/auth/dto/AccountDeleteRequest.java
+++ b/src/main/java/hansung/hansung_connect/auth/dto/AccountDeleteRequest.java
@@ -1,0 +1,8 @@
+package hansung.hansung_connect.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AccountDeleteRequest(
+        @NotBlank String refreshToken  // 본인 확인 및 탈취 방지 목적
+) {
+}

--- a/src/main/java/hansung/hansung_connect/auth/dto/AccountDeleteResponse.java
+++ b/src/main/java/hansung/hansung_connect/auth/dto/AccountDeleteResponse.java
@@ -1,0 +1,9 @@
+package hansung.hansung_connect.auth.dto;
+
+import java.time.Instant;
+
+public record AccountDeleteResponse(
+        Long userId,
+        Instant deletedAt
+) {
+}

--- a/src/main/java/hansung/hansung_connect/auth/service/AuthService.java
+++ b/src/main/java/hansung/hansung_connect/auth/service/AuthService.java
@@ -1,5 +1,8 @@
 package hansung.hansung_connect.auth.service;
 
+import hansung.hansung_connect.auth.converter.AuthConverter;
+import hansung.hansung_connect.auth.dto.AccountDeleteRequest;
+import hansung.hansung_connect.auth.dto.AccountDeleteResponse;
 import hansung.hansung_connect.auth.dto.LoginResponse;
 import hansung.hansung_connect.auth.dto.OnboardingRequest;
 import hansung.hansung_connect.auth.kakao.KakaoClient;
@@ -68,5 +71,29 @@ public class AuthService {
     @Transactional
     public void logout(Long userId, String refreshToken) {
         refreshTokenRepository.deleteByToken(refreshToken);
+    }
+
+    @Transactional
+    public AccountDeleteResponse withdraw(Long userId, AccountDeleteRequest req) {
+        // 1) 전달된 refreshToken이 유효한지, 그리고 주인이 본인인지 검증
+        var jwt = req.refreshToken();
+        if (!tokenProvider.validate(jwt) || !tokenProvider.isRefreshToken(jwt)) {
+            // 프로젝트의 전역 예외 체계에 맞게 치환 가능
+            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.");
+        }
+        Long ownerId = tokenProvider.getUserId(jwt);
+        if (!ownerId.equals(userId)) {
+            throw new IllegalArgumentException("요청자와 토큰 소유자가 일치하지 않습니다.");
+        }
+
+        // 2) 리프레시 토큰 전부 삭제
+        refreshTokenRepository.deleteAllByUser_Id(userId);
+
+        // 3) 사용자 삭제(하드 딜리트)
+        User user = userRepository.findById(userId).orElseThrow();
+        userRepository.delete(user);
+
+        // 4) 응답
+        return AuthConverter.toDeleteResponse(userId);
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
@@ -76,6 +76,7 @@ public class UserController {
     @Operation(
             summary = "내 프로필(기본 정보) 부분수정",
             description = """
+                    `🔒 JWT 인증(토큰) 필요` <br>
                     학번, 이름, 전공, 멘토참여여부, 구직여부만 부분 수정합니다.
                     <br><br>
                     - PATCH 이므로 전달된 필드만 반영합니다(null은 무시)  


### PR DESCRIPTION
## 🔍 관련 이슈
#67

## 💡 주요 변경사항
계정탈퇴 API를 구현

## 🎯 테스트 방법
1. 스웨거에서 계정탈퇴 API 테스트

## 🚨 논의하고 싶은 점
없습니다!