### PR TITLE
[#79] 메인화면 API 시큐리티 설정 임시 허용

### DIFF
--- a/src/main/java/hansung/hansung_connect/config/SecurityConfig.java
+++ b/src/main/java/hansung/hansung_connect/config/SecurityConfig.java
@@ -46,6 +46,8 @@ public class SecurityConfig {
                         .requestMatchers("/links/**").permitAll()
                         .requestMatchers("/users/**").permitAll()
                         .requestMatchers("/careers/**").permitAll()
+                        .requestMatchers("/posts/promotion").permitAll()
+                        .requestMatchers("/posts/popular").permitAll()
                         // 그 외는 인증 필요
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## 🔍 관련 이슈
#79

## 💡 주요 변경사항
메인화면 api 시큐리티 설정 허용

## 🎯 테스트 방법
1. 스웨거에서 메인화면 API 테스트(토큰없이)

## 🚨 논의하고 싶은 점
없습니다!