### PR TITLE
[#82] JWT 토큰에서 유저 ID 추출하기, 하드코딩 제거

### DIFF
--- a/src/main/java/hansung/hansung_connect/domain/career/controller/CareerController.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/controller/CareerController.java
@@ -1,5 +1,7 @@
 package hansung.hansung_connect.domain.career.controller;
 
+import hansung.hansung_connect.auth.token.JwtAuthFilter;
+import hansung.hansung_connect.auth.token.JwtAuthFilter.SimpleUserPrincipal;
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.career.dto.CareerRequestDTO;
 import hansung.hansung_connect.domain.career.dto.CareerRequestDTO.BatchCreateRequestDTO;
@@ -8,9 +10,11 @@ import hansung.hansung_connect.domain.career.dto.CareerResponseDTO.CreateRespons
 import hansung.hansung_connect.domain.career.service.CareerCommandService;
 import hansung.hansung_connect.domain.career.service.CareerQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,8 +42,9 @@ public class CareerController {
     )
     @PostMapping("/careers")
     public ApiResponse<CareerResponseDTO.CreateResponseDTO> createCareer(
+            @Parameter(hidden = true) @AuthenticationPrincipal SimpleUserPrincipal me,
             @RequestBody CareerRequestDTO.CreateRequestDTO requestDTO) {
-        return ApiResponse.onSuccess(careerCommandService.createCareer(requestDTO));
+        return ApiResponse.onSuccess(careerCommandService.createCareer(me.id(), requestDTO));
     }
 
     @Operation(
@@ -53,8 +58,9 @@ public class CareerController {
     )
     @PostMapping("/careers/batch")
     public ApiResponse<CareerResponseDTO.BulkCreateResponseDTO> createCareers(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @RequestBody BatchCreateRequestDTO requestDTO) {
-        return ApiResponse.onSuccess(careerCommandService.createCareers(requestDTO));
+        return ApiResponse.onSuccess(careerCommandService.createCareers(me.id(), requestDTO));
     }
 
     @Operation(
@@ -71,9 +77,10 @@ public class CareerController {
     )
     @PutMapping("/careers/{careerId}")
     public ApiResponse<CareerResponseDTO.UpdateResponseDTO> updateCareer(
+            @Parameter(hidden = true) @AuthenticationPrincipal SimpleUserPrincipal me,
             @PathVariable Long careerId,
             @RequestBody CareerRequestDTO.UpdateRequestDTO request) {
-        return ApiResponse.onSuccess(careerCommandService.updateCareer(careerId, request));
+        return ApiResponse.onSuccess(careerCommandService.updateCareer(me.id(), careerId, request));
     }
 
     @Operation(
@@ -92,11 +99,12 @@ public class CareerController {
     @Operation(
             summary = "내 커리어 전체 조회",
             description = """
-                    현재 사용자(임시 userId=1L)의 모든 커리어를 조회합니다.
+                    현재 사용자의 모든 커리어를 조회합니다.
                     """
     )
     @GetMapping("/careers/mycareers")
-    public ApiResponse<List<CreateResponseDTO>> getMyCareers() {
-        return ApiResponse.onSuccess(careerQueryService.getMyCareers());
+    public ApiResponse<List<CreateResponseDTO>> getMyCareers(
+            @Parameter(hidden = true) @AuthenticationPrincipal SimpleUserPrincipal me) {
+        return ApiResponse.onSuccess(careerQueryService.getMyCareers(me.id()));
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/career/service/CareerCommandService.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/service/CareerCommandService.java
@@ -5,11 +5,12 @@ import hansung.hansung_connect.domain.career.dto.CareerRequestDTO.BatchCreateReq
 import hansung.hansung_connect.domain.career.dto.CareerResponseDTO;
 
 public interface CareerCommandService {
-    CareerResponseDTO.CreateResponseDTO createCareer(CareerRequestDTO.CreateRequestDTO requestDTO);
+    CareerResponseDTO.CreateResponseDTO createCareer(Long userId, CareerRequestDTO.CreateRequestDTO requestDTO);
 
-    CareerResponseDTO.BulkCreateResponseDTO createCareers(BatchCreateRequestDTO requestDTO);
+    CareerResponseDTO.BulkCreateResponseDTO createCareers(Long userId, BatchCreateRequestDTO requestDTO);
 
-    CareerResponseDTO.UpdateResponseDTO updateCareer(Long careerId, CareerRequestDTO.UpdateRequestDTO requestDTO);
+    CareerResponseDTO.UpdateResponseDTO updateCareer(Long userId, Long careerId,
+                                                     CareerRequestDTO.UpdateRequestDTO requestDTO);
 
 }
 

--- a/src/main/java/hansung/hansung_connect/domain/career/service/CareerCommandServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/service/CareerCommandServiceImpl.java
@@ -38,10 +38,10 @@ public class CareerCommandServiceImpl implements CareerCommandService {
     private final UserRepository userRepository;
 
     @Override
-    public CareerResponseDTO.CreateResponseDTO createCareer(CareerRequestDTO.CreateRequestDTO requestDTO) {
+    public CareerResponseDTO.CreateResponseDTO createCareer(Long currentUserId,
+                                                            CareerRequestDTO.CreateRequestDTO requestDTO) {
         validateBusiness(requestDTO);
 
-        Long currentUserId = 1L; // TODO: 추후 SecurityContext로 교체
         User user = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
 
@@ -50,7 +50,7 @@ public class CareerCommandServiceImpl implements CareerCommandService {
     }
 
     @Override
-    public CareerResponseDTO.BulkCreateResponseDTO createCareers(BatchCreateRequestDTO requestDTO) {
+    public CareerResponseDTO.BulkCreateResponseDTO createCareers(Long currentUserId, BatchCreateRequestDTO requestDTO) {
         if (requestDTO == null || requestDTO.getItems() == null || requestDTO.getItems().isEmpty()) {
             throw new GeneralException(CAREER_BULK_EMPTY);
         }
@@ -58,7 +58,6 @@ public class CareerCommandServiceImpl implements CareerCommandService {
         // 각 항목 검증
         requestDTO.getItems().forEach(this::validateBusiness);
 
-        Long currentUserId = 1L; // TODO: 추후 SecurityContext로 교체
         User user = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
 
@@ -70,12 +69,10 @@ public class CareerCommandServiceImpl implements CareerCommandService {
 
     // 커리어 수정(전체 대체)
     @Override
-    public CareerResponseDTO.UpdateResponseDTO updateCareer(Long careerId,
+    public CareerResponseDTO.UpdateResponseDTO updateCareer(Long currentUserId, Long careerId,
                                                             CareerRequestDTO.UpdateRequestDTO requestDTO) {
         validateBusiness(requestDTO);
 
-        // TODO: SecurityContext로 대체
-        Long currentUserId = 1L;
         User user = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
 

--- a/src/main/java/hansung/hansung_connect/domain/career/service/CareerQueryService.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/service/CareerQueryService.java
@@ -7,7 +7,7 @@ import java.util.List;
 public interface CareerQueryService {
     CareerResponseDTO.CreateResponseDTO getCareer(Long careerId);
 
-    List<CreateResponseDTO> getMyCareers();
+    List<CreateResponseDTO> getMyCareers(Long userId);
 
 }
 

--- a/src/main/java/hansung/hansung_connect/domain/career/service/CareerQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/service/CareerQueryServiceImpl.java
@@ -33,8 +33,8 @@ public class CareerQueryServiceImpl implements CareerQueryService {
     }
 
     @Override
-    public List<CareerResponseDTO.CreateResponseDTO> getMyCareers() {
-        Long currentUserId = 1L; // TODO: 추후 SecurityContext로 대체
+    public List<CareerResponseDTO.CreateResponseDTO> getMyCareers(Long currentUserId) {
+        //Long currentUserId = 1L; // TODO: 추후 SecurityContext로 대체
         User user = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
 

--- a/src/main/java/hansung/hansung_connect/domain/career/service/CareerQueryServiceImpl.java
+++ b/src/main/java/hansung/hansung_connect/domain/career/service/CareerQueryServiceImpl.java
@@ -34,7 +34,6 @@ public class CareerQueryServiceImpl implements CareerQueryService {
 
     @Override
     public List<CareerResponseDTO.CreateResponseDTO> getMyCareers(Long currentUserId) {
-        //Long currentUserId = 1L; // TODO: 추후 SecurityContext로 대체
         User user = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new GeneralException(USER_NOT_FOUND));
 

--- a/src/main/java/hansung/hansung_connect/domain/commnet/controller/CommentController.java
+++ b/src/main/java/hansung/hansung_connect/domain/commnet/controller/CommentController.java
@@ -1,5 +1,6 @@
 package hansung.hansung_connect.domain.commnet.controller;
 
+import hansung.hansung_connect.auth.token.JwtAuthFilter;
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.commnet.dto.CommentRequestDto;
 import hansung.hansung_connect.domain.commnet.dto.CommentResponseDto;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,47 +33,46 @@ public class CommentController {
     )
     @PostMapping("/posts/{postId}/comments")
     public ApiResponse<CommentResponseDto.CommentCreateResponse> createComment(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @Parameter(description = "게시글 아이디", example = "1")
             @PathVariable("postId") Long postId,
             @RequestBody CommentRequestDto.CommentCreateRequest request
     ) {
-        Long userId = 1L;
-        return ApiResponse.onSuccess(commentCommandService.createComment(userId, postId, request));
+        return ApiResponse.onSuccess(commentCommandService.createComment(me.id(), postId, request));
     }
 
     @Operation(
             summary = "내 댓글 리스트 조회",
             description = """
-            작성한 댓글의 리스트를 조회하는 API입니다.
-            
-            한 페이지에 댓글의 수는 20입니다.
-            """
+                    작성한 댓글의 리스트를 조회하는 API입니다.
+                    
+                    한 페이지에 댓글의 수는 20입니다.
+                    """
     )
     @GetMapping("/comments/my")
     public ApiResponse<CommentResponseDto.CommentListResponse> getMyComments(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @Parameter(description = "페이지 번호")
             @RequestParam(defaultValue = "0") int page
     ) {
-        Long userId = 1L;
-        return ApiResponse.onSuccess(commentQueryService.getCommentsByUser(userId, page));
+        return ApiResponse.onSuccess(commentQueryService.getCommentsByUser(me.id(), page));
     }
 
     @Operation(
             summary = "댓글 삭제",
             description = """
-            댓글을 삭제하는 API입니다.
-            Path Variable로 댓글 아이디를 입력해주세요.
-            - 게시글의 작성자인 경우 모든 댓글 삭제 가능
-            - 게시글의 작성자가 아닌 경우 자신의 댓글만 삭제 가능
-            """
+                    댓글을 삭제하는 API입니다.
+                    Path Variable로 댓글 아이디를 입력해주세요.
+                    - 게시글의 작성자인 경우 모든 댓글 삭제 가능
+                    - 게시글의 작성자가 아닌 경우 자신의 댓글만 삭제 가능
+                    """
     )
     @DeleteMapping
     public ApiResponse<Void> deleteComment(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @PathVariable("commentId") Long commentId
     ) {
-
-        Long userId = 1L;
-        commentCommandService.deleteComment(userId, commentId);
+        commentCommandService.deleteComment(me.id(), commentId);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/hansung/hansung_connect/domain/link/controller/LinkController.java
+++ b/src/main/java/hansung/hansung_connect/domain/link/controller/LinkController.java
@@ -111,7 +111,6 @@ public class LinkController {
             summary = "내 외부링크 전체 조회",
             description = """
                     현재 로그인 사용자의 모든 외부링크를 조회합니다.
-                    - 임시로 userId=1L 고정 (추후 SecurityContext 연동 예정)
                     """
     )
     @GetMapping("/mylinks")

--- a/src/main/java/hansung/hansung_connect/domain/link/controller/LinkController.java
+++ b/src/main/java/hansung/hansung_connect/domain/link/controller/LinkController.java
@@ -1,5 +1,6 @@
 package hansung.hansung_connect.domain.link.controller;
 
+import hansung.hansung_connect.auth.token.JwtAuthFilter;
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.link.dto.LinkRequestDTO;
 import hansung.hansung_connect.domain.link.dto.LinkResponseDTO;
@@ -12,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,12 +44,10 @@ public class LinkController {
     )
     @PostMapping
     public ResponseEntity<LinkResponseDTO.LinkResultDTO> createLink(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @Valid @RequestBody LinkRequestDTO.CreateLinkDTO request
     ) {
-        // 현재 개발 단계이므로 userId 고정함. 추후 수정 예정
-        Long userId = 1L;
-
-        LinkResponseDTO.LinkResultDTO result = linkCommandService.createLink(userId, request);
+        LinkResponseDTO.LinkResultDTO result = linkCommandService.createLink(me.id(), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(result);
     }
 
@@ -68,11 +68,11 @@ public class LinkController {
     )
     @PutMapping("/{linkId}")
     public ResponseEntity<LinkResponseDTO.LinkResultDTO> updateLink(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @PathVariable Long linkId,
             @Valid @RequestBody LinkRequestDTO.UpdateLinkDTO request
     ) {
-        Long userId = 1L; // 개발 단계라 userId 고정
-        LinkResponseDTO.LinkResultDTO result = linkCommandService.updateLink(userId, linkId, request);
+        LinkResponseDTO.LinkResultDTO result = linkCommandService.updateLink(me.id(), linkId, request);
         return ResponseEntity.ok(result);
     }
 
@@ -86,11 +86,10 @@ public class LinkController {
     )
     @PostMapping("/batch")
     public ApiResponse<LinkResponseDTO.LinkResultListDTO> createLinksBatch(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @Valid @RequestBody LinkRequestDTO.CreateLinksDTO request
     ) {
-        // 임시로 userId 고정
-        Long userId = 1L;
-        return ApiResponse.onSuccess(linkCommandService.createLinks(userId, request));
+        return ApiResponse.onSuccess(linkCommandService.createLinks(me.id(), request));
     }
 
     @Operation(
@@ -116,8 +115,9 @@ public class LinkController {
                     """
     )
     @GetMapping("/mylinks")
-    public ApiResponse<LinkResponseDTO.LinkResultListDTO> getMyLinks() {
-        Long userId = 1L; // TODO: SecurityContext에서 꺼내도록 변경
-        return ApiResponse.onSuccess(linkQueryService.getMyLinks(userId));
+    public ApiResponse<LinkResponseDTO.LinkResultListDTO> getMyLinks(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me
+    ) {
+        return ApiResponse.onSuccess(linkQueryService.getMyLinks(me.id()));
     }
 }

--- a/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
+++ b/src/main/java/hansung/hansung_connect/domain/post/controller/PostController.java
@@ -1,5 +1,6 @@
 package hansung.hansung_connect.domain.post.controller;
 
+import hansung.hansung_connect.auth.token.JwtAuthFilter;
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.post.dto.PostRequestDto;
 import hansung.hansung_connect.domain.post.dto.PostResponseDto;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -35,23 +37,23 @@ public class PostController {
     )
     @PostMapping("")
     public ApiResponse<PostResponseDto.PostCreateResponse> createPost(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @RequestBody PostRequestDto.PostCreateRequest request
     ) {
-        Long userId = 1L;
-        return ApiResponse.onSuccess(postCommandService.createPost(userId, request));
+        return ApiResponse.onSuccess(postCommandService.createPost(me.id(), request));
     }
 
     @Operation(
             summary = "게시글 리스트 조회",
             description = """
-            게시글 유형별 리스트를 조회합니다.
-            - popular: 인기글
-            - free: 자유 게시판
-            - promotion: 홍보 게시판
-            - notice: 공지 게시글
-            
-            한 페이지에 게시글의 수는 20입니다.
-            """
+                    게시글 유형별 리스트를 조회합니다.
+                    - popular: 인기글
+                    - free: 자유 게시판
+                    - promotion: 홍보 게시판
+                    - notice: 공지 게시글
+                    
+                    한 페이지에 게시글의 수는 20입니다.
+                    """
     )
     @GetMapping("")
     public ApiResponse<PostResponseDto.PostListResponse> getPosts(
@@ -70,27 +72,27 @@ public class PostController {
     )
     @GetMapping("/{postId}")
     public ApiResponse<PostResponseDto.PostResponse> getPost(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @PathVariable("postId") Long postId
     ) {
-        Long userId = 1L;
-        return ApiResponse.onSuccess(postQueryService.getPost(userId, postId));
+        return ApiResponse.onSuccess(postQueryService.getPost(me.id(), postId));
     }
 
     @Operation(
             summary = "내 게시글 리스트 조회",
             description = """
-            작성한 게시글의 리스트를 조회하는 API입니다.
-            
-            한 페이지에 게시글의 수는 20입니다.
-            """
+                    작성한 게시글의 리스트를 조회하는 API입니다.
+                    
+                    한 페이지에 게시글의 수는 20입니다.
+                    """
     )
     @GetMapping("/my")
     public ApiResponse<PostResponseDto.PostListResponse> getMyPosts(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @Parameter(description = "페이지 번호")
             @RequestParam(defaultValue = "0") int page
     ) {
-        Long userId = 1L;
-        return ApiResponse.onSuccess(postQueryService.getPostsByUser(userId, page));
+        return ApiResponse.onSuccess(postQueryService.getPostsByUser(me.id(), page));
     }
 
     @GetMapping("/popular")
@@ -127,13 +129,11 @@ public class PostController {
                     """
     )
     public ApiResponse<PostResponseDto.PostUpdateResponse> updatePost(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @PathVariable("postId") Long postId,
             @RequestBody PostRequestDto.PostUpdateRequest request
     ) {
-
-        Long userId = 1L;
-
-        return ApiResponse.onSuccess(postCommandService.updatePost(userId, postId, request));
+        return ApiResponse.onSuccess(postCommandService.updatePost(me.id(), postId, request));
     }
 
     @DeleteMapping("/{postId}")
@@ -145,11 +145,10 @@ public class PostController {
                     """
     )
     public ApiResponse<Void> deletePost(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @PathVariable("postId") Long postId
     ) {
-
-        Long userId = 1L;
-        postCommandService.deletePost(userId, postId);
+        postCommandService.deletePost(me.id(), postId);
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
+++ b/src/main/java/hansung/hansung_connect/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package hansung.hansung_connect.domain.user.controller;
 
+import hansung.hansung_connect.auth.token.JwtAuthFilter;
 import hansung.hansung_connect.common.response.ApiResponse;
 import hansung.hansung_connect.domain.user.converter.UserConverter;
 import hansung.hansung_connect.domain.user.dto.UserRequestDTO;
@@ -8,10 +9,12 @@ import hansung.hansung_connect.domain.user.dto.UserResponseDTO.SummaryCardRespon
 import hansung.hansung_connect.domain.user.service.UserCommandService;
 import hansung.hansung_connect.domain.user.service.UserQueryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -46,12 +49,11 @@ public class UserController {
                     """
     )
     @GetMapping("/summary")
-    public ResponseEntity<ApiResponse<SummaryCardResponse>> getMySummaryCard() {
-        // TODO: 실제 배포 시 SecurityContext에서 userId 추출
-        Long currentUserId = 1L;
-
+    public ResponseEntity<ApiResponse<SummaryCardResponse>> getMySummaryCard(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me
+    ) {
         UserResponseDTO.SummaryCardResponse result =
-                userQueryService.getMySummaryCard(currentUserId);
+                userQueryService.getMySummaryCard(me.id());
 
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
@@ -66,10 +68,11 @@ public class UserController {
                     """
     )
     @GetMapping("/myprofile")
-    public ResponseEntity<ApiResponse<UserResponseDTO.MyProfileResponse>> getMyProfile() {
-        Long currentUserId = 1L; // TODO: 인증 연동 시 교체
+    public ResponseEntity<ApiResponse<UserResponseDTO.MyProfileResponse>> getMyProfile(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me
+    ) {
         return ResponseEntity.ok(
-                ApiResponse.onSuccess(userQueryService.getMyProfile(currentUserId))
+                ApiResponse.onSuccess(userQueryService.getMyProfile(me.id()))
         );
     }
 
@@ -85,15 +88,13 @@ public class UserController {
     )
     @PatchMapping("/myprofile")
     public ResponseEntity<ApiResponse<Void>> updateMyBasicProfile(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @Valid @RequestBody UserRequestDTO.UpdateBasicProfileRequest request
     ) {
-        Long currentUserId = 1L; // TODO: 인증 연동 후 SecurityContext에서 추출
-
         // 입력 정규화(공백 제거 등)
         UserRequestDTO.UpdateBasicProfileRequest normalized = userConverter.normalize(request);
 
-        // TODO: 실제 업데이트는 Command 서비스에서 처리 (예시)
-        userCommandService.updateMyBasicProfile(currentUserId, normalized);
+        userCommandService.updateMyBasicProfile(me.id(), normalized);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }
@@ -110,17 +111,13 @@ public class UserController {
     )
     @GetMapping("/mentors")
     public ResponseEntity<ApiResponse<UserResponseDTO.MentorListResponse>> getMentors(
+            @Parameter(hidden = true) @AuthenticationPrincipal JwtAuthFilter.SimpleUserPrincipal me,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "15") int size
     ) {
-        // 개발 단계: 하드코딩. 추후 SecurityContext에서 꺼내기
-        Long currentUserId = 1L;
-
-        // 강제 size=15 정책 사용 시 고정
-        // size = 15;
 
         UserResponseDTO.MentorListResponse result =
-                userQueryService.getMentors(currentUserId, page, size);
+                userQueryService.getMentors(me.id(), page, size);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }


### PR DESCRIPTION
## 🔍 관련 이슈
#82

## 💡 주요 변경사항
컨트롤러·서비스 전반에 흩어져 있는 userId = 1L 하드코딩을 전부 제거하고, JWT 액세스 토큰의 클레임에서 userId를 추출해 사용하도록 변경했습니다. 

## 🎯 테스트 방법
1. 스웨거에서 jwt 필요한 모든 api 테스트

## 🚨 논의하고 싶은 점
없습니다!